### PR TITLE
Fixes to basic auth tests

### DIFF
--- a/src/middleware/basicAuthentication.coffee
+++ b/src/middleware/basicAuthentication.coffee
@@ -16,7 +16,7 @@ cryptoCompare = (pass, client, callback) ->
 	hash = crypto.createHash client.passwordAlgorithm
 	hash.update pass
 	hash.update client.passwordSalt
-	if hash.digest('hex') == client.hash
+	if hash.digest('hex') == client.passwordHash
 		callback null, true
 	else
 		callback null, false

--- a/test/unit/basicAuthenticationTest.coffee
+++ b/test/unit/basicAuthenticationTest.coffee
@@ -41,6 +41,12 @@ shaClient =
 
 
 describe "Basic Auth", ->
+	before (done) ->
+		Client.remove({}, done)
+
+	afterEach (done) ->
+		Client.remove({}, done)
+
 	describe "with no credentials", ->
 		it "ctx.authenticated should not exist", (done) ->
 			ctx = buildEmptyCtx()


### PR DESCRIPTION
Fixes for crypto hashing

@rcrichton just some fixes for the basic auth. The original tests weren't clearing the clients collection, so we were actually testing the wrong things: i.e. always the first client who was inserted.
