### PR TITLE
Let Vagrant instances use a newer version of mongo

### DIFF
--- a/infrastructure/development/env/openhim-core-js.pp
+++ b/infrastructure/development/env/openhim-core-js.pp
@@ -11,6 +11,10 @@ Exec {
 	user => "root",
 }
 
+class { 'mongodb::globals':
+	manage_package_repo => true
+}
+
 class { "mongodb":
 	init => "upstart",
 }


### PR DESCRIPTION
@rcrichton a quick one; this allows puppet to grab a newer instance of mongo
