### PR TITLE
Issue #170: Transform path, not url (which will contain the querystring)...

### DIFF
--- a/src/middleware/router.coffee
+++ b/src/middleware/router.coffee
@@ -22,7 +22,7 @@ sendRequestToRoutes = (ctx, routes, next) ->
 		return next new Error "Cannot route transaction: Channel contains multiple primary routes and only one primary is allowed"
 
 	for route in routes
-		path = getDestinationPath route, ctx.request.url
+		path = getDestinationPath route, ctx.path
 		options =
 			hostname: route.host
 			port: route.port

--- a/test/unit/routerTest.coffee
+++ b/test/unit/routerTest.coffee
@@ -23,7 +23,7 @@ describe "HTTP Router", ->
 				ctx.authorisedChannel = channel
 				ctx.request = new Object()
 				ctx.response = new Object()
-				ctx.request.url = "/test"
+				ctx.path = ctx.request.url = "/test"
 				ctx.request.method = "GET"
 
 				router.route ctx, (err) ->
@@ -55,7 +55,7 @@ describe "HTTP Router", ->
 			ctx.authorisedChannel = channel
 			ctx.request = new Object()
 			ctx.response = new Object()
-			ctx.request.url = "/test/multicasting"
+			ctx.path = ctx.request.url = "/test/multicasting"
 			ctx.request.method = "GET"
 			return ctx
 
@@ -76,7 +76,7 @@ describe "HTTP Router", ->
 				ctx.authorisedChannel = channel
 				ctx.request = new Object()
 				ctx.response = new Object()
-				ctx.request.url = "/test"
+				ctx.path = ctx.request.url = "/test"
 				ctx.request.method = "GET"
 
 				router.route ctx, (err) ->
@@ -202,7 +202,8 @@ describe "HTTP Router", ->
 				ctx.authorisedChannel = channel
 				ctx.request = new Object()
 				ctx.response = new Object()
-				ctx.request.url = "/test"
+				ctx.path = "/test"
+				ctx.request.url = "/test?parma1=val1&parma2=val2"
 				ctx.request.method = "GET"
 				ctx.request.querystring = "parma1=val1&parma2=val2"
 
@@ -210,7 +211,7 @@ describe "HTTP Router", ->
 					if err
 						return done err
 			), (req, res) ->
-				req.url.should.eql("/test?parma1=val1&parma2=val2");
+				req.url.should.eql("/test?parma1=val1&parma2=val2")
 				done()
 
 	describe "Basic Auth", ->
@@ -290,7 +291,7 @@ describe "HTTP Router", ->
 				ctx.authorisedChannel = channel
 				ctx.request = new Object()
 				ctx.response = new Object()
-				ctx.request.url = "/test"
+				ctx.path = ctx.request.url = "/test"
 				ctx.request.method = "GET"
 
 				router.route ctx, (err) ->


### PR DESCRIPTION
Fixes #170 

@rcrichton if you could please review?

Seems [this](https://github.com/jembi/openhim-core-js/blob/47303baa5c8823df4753f6b1d36e376746f3fc8e/test/unit/routerTest.coffee#L205) test should've picked it up, but url was set without the querystring (whereas Koa sets it up with).
