### PR TITLE
Updated Koa Cors module to allow API being queried using the OPTIONS

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "request": "~2.34.0",
     "winston": "0.7.3",
     "nconf": "~0.6.9",
-    "koa-cors": "0.0.8",
+    "koa-cors": "0.0.13",
     "bcrypt-nodejs": "0.0.3",
     "monq": "0.3.1",
     "xpath": "0.0.6",


### PR DESCRIPTION
This PR relates to issue: https://github.com/jembi/openhim-core-js/issues/221. 

The issue was due to the version of Koa Cors we were using. The problem we experienced was a noted issue and the module owners has corrected this in a updated version. The update to place here:
https://github.com/evert0n/koa-cors/blob/master/index.js#L91-L95
