### PR TITLE
Added X-OpenHIM-TransactionID header fixes #222

### DIFF
--- a/src/middleware/messageStore.coffee
+++ b/src/middleware/messageStore.coffee
@@ -43,6 +43,7 @@ exports.storeTransaction = (ctx, done) ->
 			return done err
 		else
 			ctx.transactionId = tx._id
+			ctx.header['X-OpenHIM-TransactionID'] = tx._id.toString()
 			return done null, tx
 
 exports.storeResponse = (ctx, done) ->

--- a/test/unit/messageStoreTest.coffee
+++ b/test/unit/messageStoreTest.coffee
@@ -104,6 +104,7 @@ describe "MessageStore", ->
 					(trans != null).should.be.true
 					trans.request.headers['dot．header'].should.equal '123'
 					trans.request.headers['dollar＄header'].should.equal '124'
+					ctx.header['X-OpenHIM-TransactionID'].should.equal result._id.toString()
 					done()
 
 	describe ".storeResponse", ->


### PR DESCRIPTION
@rcrichton please review added the transaction ID header and tested whether the messageStore middleware enriches the ctx object with the new transaction ID from the database.
