### PR TITLE
Downgraded Koa Cors version - issue with Access-Control-Allow-Headers not being set correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "request": "~2.34.0",
     "winston": "0.7.3",
     "nconf": "~0.6.9",
-    "koa-cors": "0.0.13",
+    "koa-cors": "0.0.11",
     "bcrypt-nodejs": "0.0.3",
     "monq": "0.3.1",
     "xpath": "0.0.6",


### PR DESCRIPTION
After a bit of investigation i found that Koa Cors does not set the correct "Access-Control-Allow-Headers". If no options is supplied for cors() then it should the 'access-control-request-headers'. These headers include 'content-type' when updating/adding a record. with the 0.0.12 and 0.0.13 version of Cors this does not seem to be happening

Reverting Koa Cors to version 0.0.11 as this fixes the saving issue as well as the preflight options issue previously fixed
