### PR TITLE
Puppet script fix

### DIFF
--- a/infrastructure/deployment/env/openhim-core-js.pp
+++ b/infrastructure/deployment/env/openhim-core-js.pp
@@ -52,7 +52,7 @@ exec { "npm-install":
 }
 
 exec { "coffeescript":
-  cwd => "$source_dir",
+	cwd => "$source_dir",
 	command => "npm install -g coffee-script",
 	unless => "npm list -g coffee-script",
 	require => Nodejs::Install["node-v0.11.11"],


### PR DESCRIPTION
The puppet script had a missing 'cwd' for the coffeescript execute command. This prevented coffeescript from being installed and the build process failing
