### PR TITLE
Fixed X-OpenHIM-TransactionID Header

### DIFF
--- a/src/middleware/messageStore.coffee
+++ b/src/middleware/messageStore.coffee
@@ -100,8 +100,6 @@ exports.storeResponse = (ctx, done) ->
 exports.koaMiddleware =  `function *storeMiddleware(next) {
 		var saveTransaction = Q.denodeify(exports.storeTransaction);
 		yield saveTransaction(this);
-		if (this.transactionId){
-			yield next;
-		}
+		yield next;
 		exports.storeResponse(this, function(){});
 	}`


### PR DESCRIPTION
@rcrichton please review found a bug in the way this works, basically what was happening was that the the request was being made before the transaction was saved therefor the X-OpenHIM-TransactionID was not being set
