### PR TITLE
Confirm client is found and authenticated before "yield next"

### DIFF
--- a/src/middleware/tlsAuthentication.coffee
+++ b/src/middleware/tlsAuthentication.coffee
@@ -49,7 +49,7 @@ exports.koaMiddleware = `function *tlsAuthMiddleware(next) {
 				yield next;
 			}else{
 				this.response.status = "unauthorized";
-				logger.info("Certificate Authentication Failed: Certificate Name did not match your Client Domain");
+				logger.info("Certificate Authentication Failed: the certificate's common name did not match any client's domain attribute");
 			}
 		} else {
 			this.response.status = "unauthorized";


### PR DESCRIPTION
This PR relates to issue: https://github.com/jembi/openhim-core-js/issues/281
Added in a check to make sure the client is found and "this.authenticated" isn't null before moving on, otherwise client is not authenticated
