### PR TITLE
prevent "root@openhim.org" user from being deleted through the API

### DIFF
--- a/src/api/users.coffee
+++ b/src/api/users.coffee
@@ -126,6 +126,14 @@ exports.removeUser = `function *removeUser(email) {
 		return;
 	}
 
+	// Test if the user is root@openhim.org
+	if ( this.authenticated.email === 'root@openhim.org' ) {
+		logger.info('User ' +this.authenticated.email+ ' is OpenHIM root, User cannot be deleted through the API')
+		this.body = 'User ' +this.authenticated.email+ ' is OpenHIM root, User cannot be deleted through the API'
+		this.status = 'forbidden';
+		return;
+	}
+
 	var email = unescape (email);
 
 	try {


### PR DESCRIPTION
This PR relates to issue: https://github.com/jembi/openhim-core-js/issues/285
Added in a check to ensure that root@openhim.org cannot be deleted via the API
