### PR TITLE
Fixed issue for root user not being allowed to be deleted

### DIFF
--- a/src/api/users.coffee
+++ b/src/api/users.coffee
@@ -126,15 +126,15 @@ exports.removeUser = `function *removeUser(email) {
     return;
   }
 
+  var email = unescape (email);
+
   // Test if the user is root@openhim.org
-  if ( this.authenticated.email === 'root@openhim.org' ) {
+  if ( email === 'root@openhim.org' ) {
     logger.info('User ' +this.authenticated.email+ ' is OpenHIM root, User cannot be deleted through the API')
     this.body = 'User ' +this.authenticated.email+ ' is OpenHIM root, User cannot be deleted through the API'
     this.status = 'forbidden';
     return;
   }
-
-  var email = unescape (email);
 
   try {
     yield User.findOneAndRemove({ email: email }).exec();


### PR DESCRIPTION
This is an issue that slipped  past a previous PR. Fixed issue with root user not being able to delete any user.
Should be that root user cant be deleted
