### PR TITLE
Handle tcp errors and don't write to closed sockets

### DIFF
--- a/src/tcpAdapter.coffee
+++ b/src/tcpAdapter.coffee
@@ -40,7 +40,7 @@ exports.startupTCPServer = startupTCPServer = (channel, callback) ->
 
   handler = (sock) ->
     sock.on 'data', (data) -> adaptSocketRequest channel, sock, "#{data}"
-    sock.on 'close', ->
+    sock.on 'error', (err) -> logger.error err
 
   if channel.type is 'tls'
     tlsAuthentication.getServerOptions true, (err, options) ->
@@ -94,7 +94,9 @@ adaptSocketRequest = (channel, sock, socketData) ->
   req = http.request options, (res) ->
     response = ''
     res.on 'data', (data) -> response += data
-    res.on 'end', -> sock.write response
+    res.on 'end', ->
+      if sock.writable
+        sock.write response
 
   req.on "error", (err) -> logger.error err
 

--- a/test/integration/tcpIntegrationTests.coffee
+++ b/test/integration/tcpIntegrationTests.coffee
@@ -86,8 +86,7 @@ describe "TCP/TLS Integration Tests", ->
     cert: (fs.readFileSync "test/resources/client-tls/cert.pem").toString()
 
   sendTCPTestMessage = (port, callback) ->
-    client = new net.Socket()
-    client.connect port, 'localhost', -> client.write testMessage
+    client = net.connect port, 'localhost', -> client.write testMessage
     client.on 'data', (data) ->
       client.end()
       callback "#{data}"
@@ -131,6 +130,12 @@ describe "TCP/TLS Integration Tests", ->
         incrementTransactionCountSpy.getCall(0).args[0].authorisedChannel.should.have.property 'name', 'TCPIntegrationChannel1'
         measureTransactionDurationSpy.calledOnce.should.be.true
         done()
+
+  it "should handle disconnected clients", (done) ->
+    server.start null, null, null, null, 7787, null, ->
+      client = net.connect 4000, 'localhost', ->
+        client.on 'close', -> server.stop done
+        client.end 'test'
 
   it "should route TLS messages", (done) ->
     server.start null, null, null, null, 7787, null, ->


### PR DESCRIPTION
* Checked to see if the socket is writable before writing to it in case the client has disconnected. (#272)
* Added an error listener so that connection errors do not crash the HIM. (#315)