### PR TITLE
Channels deleted flag

### DIFF
--- a/src/api/channels.coffee
+++ b/src/api/channels.coffee
@@ -34,7 +34,7 @@ exports.getChannels = `function *getChannels() {
 
 processPostAddTriggers = (channel) ->
   if channel.type and authMiddleware.isChannelEnabled channel
-    if channel.type is 'tcp' and server.isTcpHttpReceiverRunning()
+    if (channel.type is 'tcp' or channel.type is 'tls') and server.isTcpHttpReceiverRunning()
       tcpAdapter.startupTCPServer channel, (err) -> logger.error err if err
     else if channel.type is 'polling'
       polling.registerPollingChannel channel, (err) -> logger.error err if err
@@ -129,7 +129,7 @@ exports.getChannel = `function *getChannel(channelId) {
 
 processPostUpdateTriggers = (channel) ->
   if channel.type
-    if channel.type is 'tcp' and server.isTcpHttpReceiverRunning()
+    if (channel.type is 'tcp' or channel.type is 'tls') and server.isTcpHttpReceiverRunning()
       if authMiddleware.isChannelEnabled channel
         tcpAdapter.startupTCPServer channel, (err) -> logger.error err if err
       else
@@ -190,7 +190,7 @@ exports.updateChannel = `function *updateChannel(channelId) {
 
 processPostDeleteTriggers = (channel) ->
   if channel.type
-    if channel.type is 'tcp' and server.isTcpHttpReceiverRunning()
+    if (channel.type is 'tcp' or channel.type is 'tls') and server.isTcpHttpReceiverRunning()
       tcpAdapter.stopServerForChannel channel, (err) -> logger.error err if err
     else if channel.type is 'polling'
       polling.removePollingChannel channel, (err) -> logger.error err if err

--- a/src/middleware/authorisation.coffee
+++ b/src/middleware/authorisation.coffee
@@ -64,6 +64,11 @@ if process.env.NODE_ENV == "test"
   exports.matchJsonPath = matchJsonPath
   exports.extractContentType = extractContentType
 
+# Is the channel enabled?
+# If there is no status field then the channel IS enabled
+checkChannelStatus = (channel) -> not channel.status or channel.status is 'enabled'
+
+
 exports.authorise = (ctx, done) ->
   Channel.find {}, (err, channels) ->
     for channel in channels
@@ -85,8 +90,8 @@ exports.authorise = (ctx, done) ->
               # deny access to channel if the content type isn't set
               continue
 
-          # now check if message content matches
-          if matchContent(channel, ctx.body) is true
+          # now check if message content matches and that the status is 'enabled'
+          if matchContent(channel, ctx.body) and checkChannelStatus channel
             ctx.authorisedChannel = channel
             logger.info "The request, '" + ctx.request.url + "' is authorised to access " + ctx.authorisedChannel.name
             return done()

--- a/src/middleware/authorisation.coffee
+++ b/src/middleware/authorisation.coffee
@@ -66,7 +66,7 @@ if process.env.NODE_ENV == "test"
 
 # Is the channel enabled?
 # If there is no status field then the channel IS enabled
-checkChannelStatus = (channel) -> not channel.status or channel.status is 'enabled'
+exports.isChannelEnabled = isChannelEnabled = (channel) -> not channel.status or channel.status is 'enabled'
 
 
 exports.authorise = (ctx, done) ->
@@ -91,7 +91,7 @@ exports.authorise = (ctx, done) ->
               continue
 
           # now check if message content matches and that the status is 'enabled'
-          if matchContent(channel, ctx.body) and checkChannelStatus channel
+          if matchContent(channel, ctx.body) and isChannelEnabled channel
             ctx.authorisedChannel = channel
             logger.info "The request, '" + ctx.request.url + "' is authorised to access " + ctx.authorisedChannel.name
             return done()

--- a/src/middleware/authorisation.coffee
+++ b/src/middleware/authorisation.coffee
@@ -90,8 +90,8 @@ exports.authorise = (ctx, done) ->
               # deny access to channel if the content type isn't set
               continue
 
-          # now check if message content matches and that the status is 'enabled'
-          if matchContent(channel, ctx.body) and isChannelEnabled channel
+          # now check that the status is 'enabled' and if the message content matches
+          if isChannelEnabled(channel) and matchContent(channel, ctx.body)
             ctx.authorisedChannel = channel
             logger.info "The request, '" + ctx.request.url + "' is authorised to access " + ctx.authorisedChannel.name
             return done()

--- a/src/model/channels.coffee
+++ b/src/model/channels.coffee
@@ -55,6 +55,7 @@ ChannelSchema = new Schema
       { type: String, required: false }
   ]
   "alerts": [ AlertsSchema ]
+  "status": { type: String, required: false, default: 'enabled', enum: ['enabled', 'disabled', 'deleted'] }
 
 # compile the Channel and Route Schema into a Model
 exports.Route = mongoose.model 'Route', RouteSchema

--- a/src/polling.coffee
+++ b/src/polling.coffee
@@ -5,6 +5,7 @@ config.polling = config.get('polling')
 logger = require 'winston'
 Q = require 'q'
 logger = require 'winston'
+authorisation = require './middleware/authorisation'
 
 exports.agendaGlobal = null
 
@@ -42,7 +43,8 @@ exports.setupAgenda = (agenda, callback) ->
 
     promises = []
     for channel in channels
-      promises.push registerPollingChannelPromise channel
+      if authorisation.isChannelEnabled channel
+        promises.push registerPollingChannelPromise channel
 
     (Q.all promises).done callback
 

--- a/src/tcpAdapter.coffee
+++ b/src/tcpAdapter.coffee
@@ -116,10 +116,10 @@ adaptSocketRequest = (channel, sock, socketData) ->
   req.end()
 
 
-exports.stopServers = (callback) ->
+stopTCPServers = (servers, callback) ->
   promises = []
 
-  for server in tcpServers
+  for server in servers
     do (server) ->
       defer = Q.defer()
 
@@ -129,9 +129,22 @@ exports.stopServers = (callback) ->
 
       promises.push defer.promise
 
-  (Q.all promises).then ->
+  (Q.all promises).then -> callback()
+
+exports.stopServers = (callback) ->
+  stopTCPServers tcpServers, ->
     tcpServers = []
     callback()
+
+exports.stopServerForChannel = (channel, callback) ->
+  server = null
+  for s in tcpServers
+    if s.channelID.equals channel._id
+      server = s
+
+  return callback "Server for channel #{channel._id} not running" if not server
+
+  stopTCPServers [s], callback
 
 
 if process.env.NODE_ENV == "test"

--- a/src/tcpAdapter.coffee
+++ b/src/tcpAdapter.coffee
@@ -124,7 +124,7 @@ stopTCPServers = (servers, callback) ->
       defer = Q.defer()
 
       server.server.close (err) ->
-        logger.info "Channel #{server.channelID}: Stopped TCP server"
+        logger.info "Channel #{server.channelID}: Stopped TCP/TLS server"
         defer.resolve()
 
       promises.push defer.promise
@@ -138,12 +138,17 @@ exports.stopServers = (callback) ->
 
 exports.stopServerForChannel = (channel, callback) ->
   server = null
+  notStoppedTcpServers = []
   for s in tcpServers
     if s.channelID.equals channel._id
       server = s
+    else
+      # push all except the server we're stopping
+      notStoppedTcpServers.push s
 
   return callback "Server for channel #{channel._id} not running" if not server
 
+  tcpServers = notStoppedTcpServers
   stopTCPServers [s], callback
 
 

--- a/test/integration/channelsAPITests.coffee
+++ b/test/integration/channelsAPITests.coffee
@@ -12,7 +12,7 @@ describe "API Integration Tests", ->
 
   describe 'Channels REST Api testing', ->
 
-    channel1 = new Channel
+    channel1 = {
       name: "TestChannel1"
       urlPattern: "test/sample"
       allow: [ "PoC", "Test1", "Test2" ]
@@ -23,8 +23,9 @@ describe "API Integration Tests", ->
             primary: true
           ]
       txViewAcl: "aGroup"
+    }
 
-    channel2 = new Channel
+    channel2 = {
       name: "TestChannel2"
       urlPattern: "test/sample"
       allow: [ "PoC", "Test1", "Test2" ]
@@ -35,26 +36,31 @@ describe "API Integration Tests", ->
             primary: true
           ]
       txViewAcl: "group1"
+    }
 
     authDetails = {}
 
     before (done) ->
-      Channel.remove {}, ->
-        channel1.save ->
-          channel2.save ->
-            auth.setupTestUsers (err) ->
-              return done err if err
-              server.start null, null, 8080, null, 7787, null, ->
-                done()
+      auth.setupTestUsers (err) ->
+        return done err if err
+        server.start null, null, 8080, null, 7787, null, ->
+          authDetails = auth.getAuthDetails()
+          done()
 
     after (done) ->
-      server.stop ->
-        auth.cleanupTestUsers ->
-          Channel.remove {}, ->
+      Channel.remove {}, ->
+        server.stop ->
+          auth.cleanupTestUsers ->
             done()
 
-    beforeEach ->
-      authDetails = auth.getAuthDetails()
+    beforeEach (done) ->
+      Channel.remove {}, ->
+        (new Channel channel1).save (err, ch1) ->
+          channel1._id = ch1._id
+          (new Channel channel2).save (err, ch2) ->
+            channel2._id = ch2._id
+            done()
+
 
     describe '*getChannels()', ->
 

--- a/test/unit/authorisationTest.coffee
+++ b/test/unit/authorisationTest.coffee
@@ -298,6 +298,108 @@ describe "Authorisation middleware", ->
           (ctx.authorisedChannel == undefined).should.be.true
           done()
 
+    it "should allow a request if the client is authorised and the channel is enabled", (done) ->
+      # Setup a channel for the mock endpoint
+      channel = new Channel
+        name: "Mock for Channel Status Test (enabled)"
+        urlPattern: "test/status/enabled"
+        allow: [ "PoC", "Test1", "Test2" ]
+        routes: [
+              name: "test route"
+              host: "localhost"
+              port: 9876
+              primary: true
+            ]
+        status: "enabled"
+      addedChannelNames.push channel.name
+      channel.save (err) ->
+        if err
+          return done err
+
+        # Setup test data, will need authentication mechanisms to set ctx.authenticated
+        ctx = {}
+        ctx.authenticated =
+          clientID: "Musha_OpenMRS"
+          domain: "poc1.jembi.org"
+          name: "OpenMRS Musha instance"
+          roles: [ "OpenMRS_PoC", "PoC" ]
+          passwordHash: ""
+          cert: ""
+        ctx.request = {}
+        ctx.request.url = "test/status/enabled"
+        ctx.response = {}
+        authorisation.authorise ctx, ->
+          ctx.authorisedChannel.should.exist
+          done()
+
+    it "should NOT allow a request if the client is authorised but the channel is disabled", (done) ->
+      # Setup a channel for the mock endpoint
+      channel = new Channel
+        name: "Mock for Channel Status Test (disabled)"
+        urlPattern: "test/status/disabled"
+        allow: [ "PoC", "Test1", "Test2" ]
+        routes: [
+              name: "test route"
+              host: "localhost"
+              port: 9876
+              primary: true
+            ]
+        status: "disabled"
+      addedChannelNames.push channel.name
+      channel.save (err) ->
+        if err
+          return done err
+
+        # Setup test data, will need authentication mechanisms to set ctx.authenticated
+        ctx = {}
+        ctx.authenticated =
+          clientID: "Musha_OpenMRS"
+          domain: "poc1.jembi.org"
+          name: "OpenMRS Musha instance"
+          roles: [ "OpenMRS_PoC", "PoC" ]
+          passwordHash: ""
+          cert: ""
+        ctx.request = {}
+        ctx.request.url = "test/status/disabled"
+        ctx.response = {}
+        authorisation.authorise ctx, ->
+          (ctx.authorisedChannel == undefined).should.be.true
+          done()
+
+    it "should NOT allow a request if the client is authorised but the channel is deleted", (done) ->
+      # Setup a channel for the mock endpoint
+      channel = new Channel
+        name: "Mock for Channel Status Test (deleted)"
+        urlPattern: "test/status/deleted"
+        allow: [ "PoC", "Test1", "Test2" ]
+        routes: [
+              name: "test route"
+              host: "localhost"
+              port: 9876
+              primary: true
+            ]
+        status: "disabled"
+      addedChannelNames.push channel.name
+      channel.save (err) ->
+        if err
+          return done err
+
+        # Setup test data, will need authentication mechanisms to set ctx.authenticated
+        ctx = {}
+        ctx.authenticated =
+          clientID: "Musha_OpenMRS"
+          domain: "poc1.jembi.org"
+          name: "OpenMRS Musha instance"
+          roles: [ "OpenMRS_PoC", "PoC" ]
+          passwordHash: ""
+          cert: ""
+        ctx.request = {}
+        ctx.request.url = "test/status/deleted"
+        ctx.response = {}
+        authorisation.authorise ctx, ->
+          (ctx.authorisedChannel == undefined).should.be.true
+          done()
+
   describe '.matchReg(regexPat, body)', ->
 
     it 'should return true if the regex pattern finds a match in the body', ->

--- a/test/unit/authorisationTest.coffee
+++ b/test/unit/authorisationTest.coffee
@@ -378,7 +378,7 @@ describe "Authorisation middleware", ->
               port: 9876
               primary: true
             ]
-        status: "disabled"
+        status: "deleted"
       addedChannelNames.push channel.name
       channel.save (err) ->
         if err

--- a/test/unit/pollingTest.coffee
+++ b/test/unit/pollingTest.coffee
@@ -24,8 +24,16 @@ describe 'Polling tests', ->
     type: 'polling'
     pollingSchedule: '2 * * * *'
 
+  disabledChannel = new Channel
+    name: 'disabled'
+    urlPattern: '/disabled'
+    allow: '*'
+    type: 'polling'
+    pollingSchedule: '* * * * *'
+    status: 'disabled'
+
   before (done) ->
-    testChannel.save -> testChannel2.save -> testChannel3.save -> done()
+    testChannel.save -> testChannel2.save -> testChannel3.save -> disabledChannel.save -> done()
 
   createSpy = ->
     agenda =
@@ -87,10 +95,11 @@ describe 'Polling tests', ->
       polling.agendaGlobal.should.be.exactly mockAgenda
       done()
 
-    it 'should register a channel for each polling channel', (done) ->
+    it 'should register a channel for each enabled polling channel', (done) ->
       spy = sinon.spy polling, 'registerPollingChannel'
       polling.setupAgenda createSpy(), ->
         spy.calledTwice.should.be.true
         spy.calledWith testChannel
         spy.calledWith testChannel3
+        spy.neverCalledWith disabledChannel
         done()

--- a/test/unit/tcpAdapterTest.coffee
+++ b/test/unit/tcpAdapterTest.coffee
@@ -1,0 +1,40 @@
+should = require "should"
+sinon = require "sinon"
+tcpAdapter = require '../../lib/tcpAdapter'
+Channel = require("../../lib/model/channels").Channel
+
+describe 'TCP adapter tests', ->
+
+  testChannel = new Channel
+    name: 'test'
+    urlPattern: '/test'
+    allow: '*'
+    type: 'tcp'
+    tcpPort: 4000
+    tcpHost: 'localhost'
+
+  disabledChannel = new Channel
+    name: 'disabled'
+    urlPattern: '/disabled'
+    allow: '*'
+    type: 'tcp'
+    tcpPort: 4001
+    tcpHost: 'localhost'
+    status: 'disabled'
+
+  before (done) ->
+    testChannel.save -> disabledChannel.save -> done()
+
+  after (done) ->
+    tcpAdapter.stopServers -> Channel.remove {}, done
+
+  describe '.startupServers', ->
+    it 'should startup all enabled channels', (done) ->
+      spy = sinon.spy tcpAdapter, 'startupTCPServer'
+      tcpAdapter.startupServers ->
+        try
+          spy.calledOnce.should.be.true
+          spy.calledWith testChannel
+        catch err
+          return done err
+        done()


### PR DESCRIPTION
Closes #324 

@rcrichton if you could please review?

Tested everything through the API and seems to be working fine.

Currently when someone tries to delete a channel, it will first check to see if there are any linked transactions. If not it will still properly remove the channel (useful if they added a bad channel or something), otherwise it sets the flag.