### PR TITLE
Add the option to specify a bind address

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,5 @@
 {
+  "bindAddress": "0.0.0.0",
   "mongo": {
     "url": "mongodb://localhost/openhim"
   },

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -71,7 +71,7 @@ stopAgenda = ->
     logger.info "Stopped agenda job scheduler"
   return defer
 
-startHttpServer = (httpPort, app) ->
+startHttpServer = (httpPort, bindAddress, app) ->
   deferred = Q.defer()
 
   httpServer = http.createServer app.callback()
@@ -80,13 +80,13 @@ startHttpServer = (httpPort, app) ->
   httpServer.setTimeout config.router.timeout, ->
     logger.info "HTTP socket timeout reached"
 
-  httpServer.listen httpPort, ->
+  httpServer.listen httpPort, bindAddress, ->
     logger.info "HTTP listening on port " + httpPort
     deferred.resolve()
 
   return deferred
 
-startHttpsServer = (httpsPort, app) ->
+startHttpsServer = (httpsPort, bindAddress, app) ->
   deferred = Q.defer()
 
   mutualTLS = config.authentication.enableMutualTLSAuthentication
@@ -99,7 +99,7 @@ startHttpsServer = (httpsPort, app) ->
     httpsServer.setTimeout config.router.timeout, ->
       logger.info "HTTPS socket timeout reached"
 
-    httpsServer.listen httpsPort, ->
+    httpsServer.listen httpsPort, bindAddress, ->
       logger.info "HTTPS listening on port " + httpsPort
       deferred.resolve()
 
@@ -120,7 +120,7 @@ ensureRootUser = (callback) ->
     else
       callback()
 
-startApiServer = (apiPort, app) ->
+startApiServer = (apiPort, bindAddress, app) ->
   deferred = Q.defer()
 
   # mutualTLS not applicable for the API - set false
@@ -129,7 +129,7 @@ startApiServer = (apiPort, app) ->
     return done err if err
 
     apiHttpsServer = https.createServer options, app.callback()
-    apiHttpsServer.listen apiPort, ->
+    apiHttpsServer.listen apiPort, bindAddress, ->
       logger.info "API HTTPS listening on port " + apiPort
       ensureRootUser -> deferred.resolve()
 
@@ -169,17 +169,18 @@ startPollingServer = (pollingPort, app) ->
   return defer
 
 exports.start = (httpPort, httpsPort, apiPort, rerunHttpPort, tcpHttpReceiverPort, pollingPort, done) ->
-  logger.info "Starting OpenHIM server..."
+  bindAddress = config.get 'bindAddress'
+  logger.info "Starting OpenHIM server on #{bindAddress}..."
   promises = []
 
   if httpPort or httpsPort
     koaMiddleware.setupApp (app) ->
-      promises.push startHttpServer(httpPort, app).promise if httpPort
-      promises.push startHttpsServer(httpsPort, app).promise if httpsPort
+      promises.push startHttpServer(httpPort, bindAddress, app).promise if httpPort
+      promises.push startHttpsServer(httpsPort, bindAddress, app).promise if httpsPort
 
   if apiPort
     koaApi.setupApp (app) ->
-      promises.push startApiServer(apiPort, app).promise
+      promises.push startApiServer(apiPort,bindAddress,  app).promise
 
   if rerunHttpPort
     koaMiddleware.rerunApp (app) ->


### PR DESCRIPTION
This only applies to the HTTP, HTTPS and API server since the polling, rerun and TCP adapters are already bound to localhost.

Closes #385.