### PR TITLE
Look up authorised channel on rerun

### DIFF
--- a/src/middleware/rerunBypassAuthorisation.coffee
+++ b/src/middleware/rerunBypassAuthorisation.coffee
@@ -1,13 +1,15 @@
 auth = require 'basic-auth'
-Q = require "q"
-Transaction = require("../model/transactions").Transaction
-logger = require "winston"
+Channel = require('../model/channels').Channel
+logger = require 'winston'
+Transaction = require('../model/transactions').Transaction
+Q = require 'q'
 
 exports.authoriseUser = (ctx, done) ->
   # Use the original transaction's channel to setup the authorised channel
   Transaction.findOne _id: ctx.parentID, (err, originalTransaction) ->
-    ctx.authorisedChannel = { _id: originalTransaction.channelID }
-    done()
+    Channel.findOne _id: originalTransaction.channelID, (err, authorisedChannel) ->
+      ctx.authorisedChannel = authorisedChannel
+      done()
   
 
 ###


### PR DESCRIPTION
I am seeing the following error on staging when rerunning a transaction:

```
  TypeError: Cannot read property 'length' of undefined
      at containsMultiplePrimaries (/opt/openhim-core-js/lib/middleware/router.js:38:29)
      at sendRequestToRoutes (/opt/openhim-core-js/lib/middleware/router.js:155:7)
      at exports.route (/opt/openhim-core-js/lib/middleware/router.js:469:10)
      at Promise.apply (/opt/openhim-core-js/node_modules/q/q.js:1107:26)
      at Promise.promise.promiseDispatch (/opt/openhim-core-js/node_modules/q/q.js:748:41)
      at /opt/openhim-core-js/node_modules/q/q.js:1333:14
      at flush (/opt/openhim-core-js/node_modules/q/q.js:110:17)
      at process._tickDomainCallback (node.js:381:11)
```

This correlates to https://github.com/jembi/openhim-core-js/blob/master/src/middleware/router.coffee#L19 in the coffeescript.

The issue is caused by https://github.com/jembi/openhim-core-js/blob/master/src/middleware/router.coffee#L361-L362 when rerunning a transaction because the authorised channel only has an `_id` property so routes is undefined.