### PR TITLE
Updated model required field for path and method

### DIFF
--- a/src/model/transactions.coffee
+++ b/src/model/transactions.coffee
@@ -3,11 +3,11 @@ Schema = mongoose.Schema
 
 # Request Schema definition
 RequestDef =
-  "path" :{ type: String, required: true }
+  "path" :{ type: String, required: false }
   "headers": {type: Object}
   "querystring": { type: String }
   "body":{ type: String}
-  "method":{ type: String, required: true }
+  "method":{ type: String, required: false }
   "timestamp":{ type: Date, required: true }
 
 # Response Schema definition


### PR DESCRIPTION
This PR relates to issue: #410 

Some channels or orchestrations don't always have request.path or request.method value so the rerun update function didn't execute correctly and failed to update.