### PR TITLE
Disabled make-install for node.js in puppet

### DIFF
--- a/infrastructure/development/env/openhim-core-js.pp
+++ b/infrastructure/development/env/openhim-core-js.pp
@@ -28,6 +28,7 @@ class { 'mongodb::client': }
 
 class { "nodejs":
 	version => "stable",
+    make_install => false,
 }
 
 exec { "npm-install":


### PR DESCRIPTION
@rcrichton just a quick one: disabled makeinstall for node in puppet. This improves vagrant startup times drastically