### PR TITLE
Minor fix to transaction API - getTransactionById()

### DIFF
--- a/src/api/transactions.coffee
+++ b/src/api/transactions.coffee
@@ -154,7 +154,7 @@ exports.getTransactionById = (transactionId) ->
     result = yield transactions.Transaction.findById(transactionId, projectionFiltersObject).exec()
 
     # Test if the result if valid
-    if result?.length is 0
+    if not result
       this.body = "Could not find transaction with ID: #{transactionId}"
       this.status = 'not found'
     # Test if the user is authorised


### PR DESCRIPTION
Found this bug in transactions -> find by ID. 

The result returned is not an array but rather an object when searching for a specific record. If the result is null (not found) then a server error is thrown on .length. 

Replicate: View a valid transaction details. Change the URL to reference an invalid transaction ID and the labels are still show as well as an error in console. 