### PR TITLE
Added syslog information to the audit model

### DIFF
--- a/src/model/audits.coffee
+++ b/src/model/audits.coffee
@@ -6,6 +6,18 @@ codeTypeSchema =
   "displayName": { type: String, required: false }
   "codeSystemName": { type: String, required: false }
 
+syslogSchema =
+  "prival": { type: Number, required: false }
+  "facilityID": { type: Number, required: false }
+  "severityID": { type: Number, required: false }
+  "facility": { type: String, required: false }
+  "severity": { type: String, required: false }
+  "type": { type: String, required: false }
+  "time": { type: Date, required: false }
+  "host": { type: String, required: false }
+  "appName": { type: String, required: false }
+  "pid": { type: String, required: false }
+  "msgID": { type: String, required: false }
 
 ActiveParticipantSchema = new Schema
   "userID": { type: String, required: false }
@@ -29,6 +41,7 @@ ParticipantObjectIdentificationSchema = new Schema
 
 AuditRecordSchema = new Schema
   "rawMessage":  { type: String, required: false }
+  "syslog": syslogSchema
   "eventIdentification":
     "eventDateTime": { type: Date, required: true, default: Date.now }
     "eventOutcomeIndicator": { type: String, required: false }


### PR DESCRIPTION
@rcrichton mind taking a look at this? I've added syslog info to the audit schema. I found a [good library](https://www.npmjs.com/package/glossy) to do the parsing and took these fields straight from what it gives us.

cc @BMartinos @debonair 