### PR TITLE
Visualizer events: async processing. Replaced create with batch driver

### DIFF
--- a/src/middleware/visualizer.coffee
+++ b/src/middleware/visualizer.coffee
@@ -52,7 +52,7 @@ addRouteEvents = (dst, route, prefix, tsDiff) ->
   if endTS-startTS<minEvPeriod then endTS = startTS+minEvPeriod
 
   # Transaction start for route
-  dst.push new events.VisualizerEvent
+  dst.push
     ts: startTS
     comp: "#{prefix}-#{route.name}"
     ev: 'start'
@@ -64,7 +64,7 @@ addRouteEvents = (dst, route, prefix, tsDiff) ->
     routeStatus = 'error'
 
   # Transaction end for route
-  dst.push new events.VisualizerEvent
+  dst.push
     ts: endTS
     comp: "#{prefix}-#{route.name}"
     ev: 'end'
@@ -81,12 +81,12 @@ storeVisualizerEvents = (ctx, done) ->
   if endTS-startTS<minEvPeriod then endTS = startTS+minEvPeriod
 
   # Transaction start for channal
-  trxEvents.push new events.VisualizerEvent
+  trxEvents.push
     ts: startTS
     comp: "channel-#{ctx.authorisedChannel.name}"
     ev: 'start'
   # Transaction start for primary route
-  trxEvents.push new events.VisualizerEvent
+  trxEvents.push
     ts: startTS
     comp: ctx.authorisedChannel.name
     ev: 'start'
@@ -116,21 +116,24 @@ storeVisualizerEvents = (ctx, done) ->
     status = 'error'
 
   # Transaction end for primary route
-  trxEvents.push new events.VisualizerEvent
+  trxEvents.push
     ts: endTS + orchestrationTsBufferMillis
     comp: ctx.authorisedChannel.name
     ev: 'end'
     status: status
   # Transaction end for channel
-  trxEvents.push new events.VisualizerEvent
+  trxEvents.push
     ts: endTS + orchestrationTsBufferMillis
     comp: "channel-#{ctx.authorisedChannel.name}"
     ev: 'end'
     status: status
 
-  events.VisualizerEvent.create trxEvents, (err) -> return if err then done err else done()
+  events.VisualizerEvent.collection.insert trxEvents, (err) -> return if err then done err else done()
 
 exports.koaMiddleware = (next) ->
   yield next
   if config.visualizer.enableVisualizer
-    storeVisualizerEvents this, ->
+    ctx = this
+    do (ctx) ->
+      f = -> storeVisualizerEvents ctx, ->
+      setTimeout f, 0

--- a/src/middleware/visualizer.coffee
+++ b/src/middleware/visualizer.coffee
@@ -128,7 +128,11 @@ storeVisualizerEvents = (ctx, done) ->
     ev: 'end'
     status: status
 
-  events.VisualizerEvent.collection.insert trxEvents, (err) -> return if err then done err else done()
+  now = new Date
+  event.created = now for event in trxEvents
+  events.VisualizerEvent.collection.createIndex { created: 1 }, { expireAfterSeconds: 600 }, ->
+    events.VisualizerEvent.collection.insert trxEvents, (err) -> return if err then done err else done()
+
 
 exports.koaMiddleware = (next) ->
   yield next

--- a/src/model/events.coffee
+++ b/src/model/events.coffee
@@ -3,9 +3,9 @@ Schema = mongoose.Schema
 
 VisualizerEventsSchema = new Schema
   "created": { type: Date, default: Date.now, expires: '10m' }
-  "ts": { type: String, required: true }
-  "comp": { type: String, required: true }
-  "ev": { type: String, required: true }
-  "status": { type: String, required: false }
+  "ts": { type: String }
+  "comp": { type: String }
+  "ev": { type: String }
+  "status": { type: String }
  
 exports.VisualizerEvent = mongoose.model 'VisualizerEvent', VisualizerEventsSchema


### PR DESCRIPTION
insert.

@rcrichton if you could please take a look? I saw in the flame graph that the visualizer usage was quite high, not super high, but still. These few improvements shave off a few ms.

It seems mongoose's `create` just loops through the array and saves each document, rather than doing a proper batch insert. If switched this out with a driver batch insert. This mean we're not doing any validations, but seems okay to me since you can't add to this collection from the API, only from this code. To reflect our lack of validation, I took out the `require`s in the model.