### PR TITLE
OHM-61: Replaced http status strings with codes for koa compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "forever-monitor": "^1.5.2",
     "glossy": "^0.1.7",
     "http-status": "^0.1.8",
-    "koa": "^0.7.0",
+    "koa": "0.18.1",
     "koa-basic-auth": "^1.1.2",
     "koa-body-parser": "^1.1.0",
     "koa-compress": "^1.0.8",

--- a/src/api/audits.coffee
+++ b/src/api/audits.coffee
@@ -27,7 +27,7 @@ getProjectionObject = (filterRepresentation) ->
 exports.addAudit = ->
   # Test if the user is authorised
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to addAudit denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to addAudit denied.", 'info'
     return
 
   auditData = this.request.body
@@ -38,11 +38,11 @@ exports.addAudit = ->
     
     logger.info "User #{this.authenticated.email} created audit with id #{audit.id}"
     this.body = 'Audit successfully created'
-    this.status = 'created'
+    this.status = 201
   catch e
     logger.error "Could not add a audit via the API: #{e.message}"
     this.body = e.message
-    this.status = 'bad request'
+    this.status = 400
 
 
 
@@ -53,7 +53,7 @@ exports.addAudit = ->
 exports.getAudits = ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getAudits denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getAudits denied.", 'info'
     return
 
   try
@@ -102,7 +102,7 @@ exports.getAudits = ->
       .sort 'eventIdentification.eventDateTime': -1
       .exec()
   catch e
-    utils.logAndSetResponse this, 'internal server error', "Could not retrieve audits via the API: #{e}", 'error'
+    utils.logAndSetResponse this, 500, "Could not retrieve audits via the API: #{e}", 'error'
 
 
 
@@ -114,7 +114,7 @@ exports.getAudits = ->
 exports.getAuditById = (auditId) ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getAuditById denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getAuditById denied.", 'info'
     return
 
   # Get the values to use
@@ -129,12 +129,12 @@ exports.getAuditById = (auditId) ->
     # Test if the result if valid
     if not result
       this.body = "Could not find audits record with ID: #{auditId}"
-      this.status = 'not found'
+      this.status = 404
     else
       this.body = result
 
   catch e
-    utils.logAndSetResponse this, 'internal server error', "Could not get audit by ID via the API: #{e}", 'error'
+    utils.logAndSetResponse this, 500, "Could not get audit by ID via the API: #{e}", 'error'
 
 
 
@@ -145,7 +145,7 @@ exports.getAuditsFilterOptions = ->
 
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getAudits denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getAudits denied.", 'info'
     return
 
   try
@@ -166,6 +166,6 @@ exports.getAuditsFilterOptions = ->
     
     this.body = responseObject
   catch e
-    utils.logAndSetResponse this, 'internal server error', "Could not retrieve audits filter options via the API: #{e}", 'error'
+    utils.logAndSetResponse this, 500, "Could not retrieve audits filter options via the API: #{e}", 'error'
 
   

--- a/src/api/authentication.coffee
+++ b/src/api/authentication.coffee
@@ -24,7 +24,7 @@ exports.authenticate = (next) ->
   if requestDate < from or requestDate > to
     # request expired
     logger.info "API request made by #{email} from #{this.request.host} has expired, denying access"
-    this.status = 'unauthorized'
+    this.status = 401
     return
 
   user = yield User.findOne(email: email).exec()
@@ -33,7 +33,7 @@ exports.authenticate = (next) ->
   if not user
     # not authenticated - user not found
     logger.info "No user exists for #{email}, denying access to API, request originated from #{this.request.host}"
-    this.status = 'unauthorized'
+    this.status = 401
     return
 
   hash = crypto.createHash 'sha512'
@@ -47,4 +47,4 @@ exports.authenticate = (next) ->
   else
     # not authenticated - token mismatch
     logger.info "API token did not match expected value, denying access to API, the request was made by #{email} from #{this.request.host}"
-    this.status = 'unauthorized'
+    this.status = 401

--- a/src/api/clients.coffee
+++ b/src/api/clients.coffee
@@ -11,7 +11,7 @@ exports.addClient = () ->
 
   # Test if the user is authorised
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to addClient denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to addClient denied.", 'info'
     return
 
   clientData = this.request.body
@@ -22,11 +22,11 @@ exports.addClient = () ->
     
     logger.info "User #{this.authenticated.email} created client with id #{client.id}"
     this.body = 'Client successfully created'
-    this.status = 'created'
+    this.status = 201
   catch e
     logger.error "Could not add a client via the API: #{e.message}"
     this.body = e.message
-    this.status = 'bad request'
+    this.status = 400
 
 ###
 # Retrieves the details of a specific client
@@ -41,12 +41,12 @@ exports.getClient = (clientId, property) ->
         _id: 0
         name: 1
     else
-      utils.logAndSetResponse this, 'not found', "The property (#{property}) you are trying to retrieve is not found.", 'info'
+      utils.logAndSetResponse this, 404, "The property (#{property}) you are trying to retrieve is not found.", 'info'
       return
   else
     # Test if the user is authorised
     if not authorisation.inGroup 'admin', this.authenticated
-      utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to findClientById denied.", 'info'
+      utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to findClientById denied.", 'info'
       return
 
   clientId = unescape clientId
@@ -54,20 +54,20 @@ exports.getClient = (clientId, property) ->
   try
     result = yield Client.findById(clientId, projectionRestriction).exec()
     if result is null
-      utils.logAndSetResponse this, 'not found', "Client with id #{clientId} could not be found.", 'info'
+      utils.logAndSetResponse this, 404, "Client with id #{clientId} could not be found.", 'info'
     else
       this.body = result
   catch e
     logger.error "Could not find client by id #{clientId} via the API: #{e.message}"
     this.body = e.message
-    this.status = 'internal server error'
+    this.status = 500
 
 
 exports.findClientByDomain = (clientDomain) ->
 
   # Test if the user is authorised
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to findClientByDomain denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to findClientByDomain denied.", 'info'
     return
 
   clientDomain = unescape clientDomain
@@ -75,19 +75,19 @@ exports.findClientByDomain = (clientDomain) ->
   try
     result = yield Client.findOne(clientDomain: clientDomain).exec()
     if result is null
-      utils.logAndSetResponse this, 'not found', "Could not find client with clientDomain #{clientDomain}", 'info'
+      utils.logAndSetResponse this, 404, "Could not find client with clientDomain #{clientDomain}", 'info'
     else
       this.body = result
   catch e
     logger.error "Could not find client by client Domain #{clientDomain} via the API: #{e.message}"
     this.body = e.message
-    this.status = 'internal server error'
+    this.status = 500
 
 exports.updateClient = (clientId) ->
 
   # Test if the user is authorised
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to updateClient denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to updateClient denied.", 'info'
     return
 
   clientId = unescape clientId
@@ -103,13 +103,13 @@ exports.updateClient = (clientId) ->
   catch e
     logger.error "Could not update client by ID #{clientId} via the API: #{e.message}"
     this.body = e.message
-    this.status = 'internal server error'
+    this.status = 500
 
 exports.removeClient = (clientId) ->
  
   # Test if the user is authorised
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to removeClient denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to removeClient denied.", 'info'
     return
 
   clientId = unescape clientId
@@ -121,13 +121,13 @@ exports.removeClient = (clientId) ->
   catch e
     logger.error "Could not remove client by ID #{clientId} via the API: #{e.message}"
     this.body = e.message
-    this.status = 'internal server error'
+    this.status = 500
 
 exports.getClients = () ->
 
   # Test if the user is authorised
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getClients denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getClients denied.", 'info'
     return
 
   try
@@ -135,4 +135,4 @@ exports.getClients = () ->
   catch e
     logger.error "Could not fetch all clients via the API: #{e.message}"
     this.message = e.message
-    this.status = 'internal server error'
+    this.status = 500

--- a/src/api/contactGroups.coffee
+++ b/src/api/contactGroups.coffee
@@ -12,7 +12,7 @@ utils = require "../utils"
 exports.addContactGroup = ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to addContactGroup denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to addContactGroup denied.", 'info'
     return
 
   contactGroupData = this.request.body
@@ -21,9 +21,9 @@ exports.addContactGroup = ->
     contactGroup = new ContactGroup contactGroupData
     result = yield Q.ninvoke(contactGroup, 'save')
 
-    utils.logAndSetResponse this, 'created', "Contact Group successfully created", 'info'
+    utils.logAndSetResponse this, 201, "Contact Group successfully created", 'info'
   catch err
-    utils.logAndSetResponse this, 'bad request', "Could not add a contact group via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 400, "Could not add a contact group via the API: #{err}", 'error'
 
 
 
@@ -33,7 +33,7 @@ exports.addContactGroup = ->
 exports.getContactGroup = (contactGroupId) ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getContactGroup denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getContactGroup denied.", 'info'
     return
 
   contactGroupId = unescape contactGroupId
@@ -43,11 +43,11 @@ exports.getContactGroup = (contactGroupId) ->
 
     if result == null
       this.body = "Contact Group with id '#{contactGroupId}' could not be found."
-      this.status = 'not found'
+      this.status = 404
     else
       this.body = result
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not find Contact Group by id '#{contactGroupId}' via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not find Contact Group by id '#{contactGroupId}' via the API: #{err}", 'error'
 
 
 
@@ -57,7 +57,7 @@ exports.getContactGroup = (contactGroupId) ->
 exports.updateContactGroup = (contactGroupId) ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to updateContactGroup denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to updateContactGroup denied.", 'info'
     return
 
   contactGroupId = unescape contactGroupId
@@ -72,7 +72,7 @@ exports.updateContactGroup = (contactGroupId) ->
     this.body = "Successfully updated contact group."
     logger.info "User #{this.authenticated.email} updated contact group with id #{contactGroupId}"
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not update Contact Group by id #{contactGroupId} via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not update Contact Group by id #{contactGroupId} via the API: #{err}", 'error'
 
 
 
@@ -83,7 +83,7 @@ exports.updateContactGroup = (contactGroupId) ->
 exports.removeContactGroup = (contactGroupId) ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to removeContactGroup denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to removeContactGroup denied.", 'info'
     return
 
   contactGroupId = unescape contactGroupId
@@ -100,14 +100,14 @@ exports.removeContactGroup = (contactGroupId) ->
       }
     }).exec()
     if linkedAlerts.length > 0
-      this.status = "conflict"
+      this.status = 409
       this.body = linkedAlerts
     else
       yield ContactGroup.findByIdAndRemove(contactGroupId).exec()
       this.body = "Successfully removed contact group with ID '#{contactGroupId}'"
       logger.info "User #{this.authenticated.email} removed contact group with id #{contactGroupId}"
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not remove Contact Group by id {contactGroupId} via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not remove Contact Group by id {contactGroupId} via the API: #{err}", 'error'
 
 
 
@@ -118,10 +118,10 @@ exports.removeContactGroup = (contactGroupId) ->
 exports.getContactGroups = ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getContactGroups denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getContactGroups denied.", 'info'
     return
 
   try
     this.body = yield ContactGroup.find().exec()
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not fetch all Contact Group via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not fetch all Contact Group via the API: #{err}", 'error'

--- a/src/api/keystore.coffee
+++ b/src/api/keystore.coffee
@@ -10,31 +10,31 @@ utils = require "../utils"
 exports.getServerCert = ->
   # Must be admin
   if authorisation.inGroup('admin', this.authenticated) is false
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getServerCert denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getServerCert denied.", 'info'
     return
 
   try
     keystoreDoc = yield Keystore.findOne().select('cert').exec()
     this.body = keystoreDoc.cert
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not fetch the server cert via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not fetch the server cert via the API: #{err}", 'error'
 
 exports.getCACerts = ->
   # Must be admin
   if authorisation.inGroup('admin', this.authenticated) is false
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getCACerts denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getCACerts denied.", 'info'
     return
 
   try
     keystoreDoc = yield Keystore.findOne().select('ca').exec()
     this.body = keystoreDoc.ca
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not fetch the ca certs trusted by this server via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not fetch the ca certs trusted by this server via the API: #{err}", 'error'
 
 exports.getCACert = (certId) ->
   # Must be admin
   if authorisation.inGroup('admin', this.authenticated) is false
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getCACert by id denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getCACert by id denied.", 'info'
     return
 
   try
@@ -43,13 +43,13 @@ exports.getCACert = (certId) ->
 
     this.body = cert
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not fetch ca cert by id via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not fetch ca cert by id via the API: #{err}", 'error'
 
 
 exports.setServerCert = ->
   # Must be admin
   if authorisation.inGroup('admin', this.authenticated) is false
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to setServerCert by id denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to setServerCert by id denied.", 'info'
     return
 
   try
@@ -58,20 +58,20 @@ exports.setServerCert = ->
     try
       certInfo = yield readCertificateInfo cert
     catch err
-      return utils.logAndSetResponse this, 'bad request', "Could not add server cert via the API: #{err}", 'error'
+      return utils.logAndSetResponse this, 400, "Could not add server cert via the API: #{err}", 'error'
     certInfo.data = cert
 
     keystoreDoc = yield Keystore.findOne().exec()
     keystoreDoc.cert = certInfo
     yield Q.ninvoke keystoreDoc, 'save'
-    this.status = 'created'
+    this.status = 201
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not add server cert via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not add server cert via the API: #{err}", 'error'
 
 exports.setServerKey = ->
   # Must be admin
   if authorisation.inGroup('admin', this.authenticated) is false
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getServerKey by id denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getServerKey by id denied.", 'info'
     return
 
   try
@@ -79,15 +79,15 @@ exports.setServerKey = ->
     keystoreDoc = yield Keystore.findOne().exec()
     keystoreDoc.key = key
     yield Q.ninvoke keystoreDoc, 'save'
-    this.status = 'created'
+    this.status = 201
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not add server key via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not add server key via the API: #{err}", 'error'
 
 
 exports.addTrustedCert = ->
   # Must be admin
   if authorisation.inGroup('admin', this.authenticated) is false
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to addTrustedCert by id denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to addTrustedCert by id denied.", 'info'
     return
 
   try
@@ -123,44 +123,44 @@ exports.addTrustedCert = ->
     yield Q.ninvoke keystoreDoc, 'save'
 
     if invalidCert
-      utils.logAndSetResponse this, 'bad request', "Failed to add one more cert, are they valid? #{err}", 'error'
+      utils.logAndSetResponse this, 400, "Failed to add one more cert, are they valid? #{err}", 'error'
     else
-      this.status = 'created'
+      this.status = 201
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not add trusted cert via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not add trusted cert via the API: #{err}", 'error'
 
 exports.removeCACert = (certId) ->
   # Must be admin
   if authorisation.inGroup('admin', this.authenticated) is false
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to removeCACert by id denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to removeCACert by id denied.", 'info'
     return
 
   try
     keystoreDoc = yield Keystore.findOne().exec()
     keystoreDoc.ca.id(certId).remove()
     yield Q.ninvoke keystoreDoc, 'save'
-    this.status = 'ok'
+    this.status = 200
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not remove ca cert by id via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not remove ca cert by id via the API: #{err}", 'error'
 
 exports.verifyServerKeys = ->
   # Must be admin
   if authorisation.inGroup('admin', this.authenticated) is false
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to verifyServerKeys.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to verifyServerKeys.", 'info'
     return
 
   try
     try
       result = yield Q.nfcall getCertKeyStatus
     catch err
-      return utils.logAndSetResponse this, 'bad request', "Could not verify certificate and key, are they valid? #{err}", 'error'
+      return utils.logAndSetResponse this, 400, "Could not verify certificate and key, are they valid? #{err}", 'error'
 
     this.body =
       valid: result
-    this.status = 'ok'
+    this.status = 200
     
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not determine validity via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not determine validity via the API: #{err}", 'error'
 
 
 

--- a/src/api/mediators.coffee
+++ b/src/api/mediators.coffee
@@ -11,20 +11,20 @@ utils = require "../utils"
 exports.getAllMediators = ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getAllMediators denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getAllMediators denied.", 'info'
     return
 
   try
     this.body = yield Mediator.find().exec()
   catch err
-    logAndSetResponse this, 'internal server error', "Could not fetch mediators via the API: #{err}", 'error'
+    logAndSetResponse this, 500, "Could not fetch mediators via the API: #{err}", 'error'
 
 
 
 exports.getMediator = (mediatorURN) ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getMediator denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getMediator denied.", 'info'
     return
 
   urn = unescape mediatorURN
@@ -32,11 +32,11 @@ exports.getMediator = (mediatorURN) ->
   try
     result = yield Mediator.findOne({ "urn": urn }).exec()
     if result == null
-      this.status = 'not found'
+      this.status = 404
     else
       this.body = result
   catch err
-    logAndSetResponse this, 'internal server error', "Could not fetch mediator using UUID {urn} via the API: #{err}", 'error'
+    logAndSetResponse this, 500, "Could not fetch mediator using UUID {urn} via the API: #{err}", 'error'
 
 
 
@@ -47,7 +47,7 @@ saveDefaultChannelConfig = (config) -> new Channel(channel).save() for channel i
 exports.addMediator = ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to addMediator denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to addMediator denied.", 'info'
     return
 
   try
@@ -74,13 +74,13 @@ exports.addMediator = ->
       yield Q.ninvoke(new Mediator(mediator), 'save')
       if mediator.defaultChannelConfig
         yield saveDefaultChannelConfig(mediator.defaultChannelConfig)
-    this.status = 'created'
+    this.status = 201
     logger.info "User #{this.authenticated.email} created mediator with urn #{mediator.urn}"
   catch err
     if err.name == 'ValidationError'
-      utils.logAndSetResponse this, 'bad request', "Could not add Mediator via the API: #{err}", 'error'
+      utils.logAndSetResponse this, 400, "Could not add Mediator via the API: #{err}", 'error'
     else
-      utils.logAndSetResponse this, 'internal server error', "Could not add Mediator via the API: #{err}", 'error'
+      utils.logAndSetResponse this, 500, "Could not add Mediator via the API: #{err}", 'error'
 
 
 
@@ -88,7 +88,7 @@ exports.addMediator = ->
 exports.removeMediator = (urn) ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to removeMediator denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to removeMediator denied.", 'info'
     return
 
   urn = unescape urn
@@ -98,4 +98,4 @@ exports.removeMediator = (urn) ->
     this.body = "Mediator with urn #{urn} has been successfully removed by #{this.authenticated.email}"
     logger.info "Mediator with urn #{urn} has been successfully removed by #{this.authenticated.email}"
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not remove Mediator by urn  {urn} via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not remove Mediator by urn  {urn} via the API: #{err}", 'error'

--- a/src/api/restart.coffee
+++ b/src/api/restart.coffee
@@ -18,7 +18,7 @@ Q = require 'q'
 exports.restart = (next) ->
   # Test if the user is authorised
   if authorisation.inGroup('admin', this.authenticated) is false
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to restart the server denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to restart the server denied.", 'info'
     return
 
   try
@@ -33,12 +33,12 @@ exports.restart = (next) ->
 
       # All ok! So set the result
       this.body = 'Server being restarted'
-      this.status = 'ok'
+      this.status = 200
     else
       # Not valid
       logger.info 'User ' +emailAddr+ ' has requested a Server Restart with invalid certificate details. Cancelling restart...'
       this.body = 'Certificates and Key did not match. Cancelling restart...'
-      this.status = 'bad request'
+      this.status = 400
 
   catch e
-    utils.logAndSetResponse this, 'bad request', "Could not restart the servers via the API: #{e}", 'error'
+    utils.logAndSetResponse this, 400, "Could not restart the servers via the API: #{e}", 'error'

--- a/src/api/tasks.coffee
+++ b/src/api/tasks.coffee
@@ -44,7 +44,7 @@ isRerunPermissionsValid = (user, transactions, callback) ->
 exports.getTasks = ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to getTasks denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to getTasks denied.", 'info'
     return
 
   try
@@ -79,7 +79,7 @@ exports.getTasks = ->
       .exec()
 
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not fetch all tasks via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not fetch all tasks via the API: #{err}", 'error'
 
 
 areTransactionChannelsValid = (transactions, callback) ->
@@ -111,7 +111,7 @@ exports.addTask = ->
 
     if transactions.batchSize?
       if transactions.batchSize <= 0
-        return utils.logAndSetResponse this, 'bad request', 'Invalid batch size specified', 'info'
+        return utils.logAndSetResponse this, 400, 'Invalid batch size specified', 'info'
       taskObject.batchSize = transactions.batchSize
 
     if transactions.paused
@@ -127,7 +127,7 @@ exports.addTask = ->
       trxChannelsValid = yield areTrxChannelsValid(transactions)
 
       if !trxChannelsValid
-        utils.logAndSetResponse this, 'bad request', 'Cannot queue task as there are transactions with disabled or deleted channels', 'info'
+        utils.logAndSetResponse this, 400, 'Cannot queue task as there are transactions with disabled or deleted channels', 'info'
         return
 
       transactionsArr.push tid: tid for tid in transactions.tids
@@ -138,13 +138,13 @@ exports.addTask = ->
       result = yield Q.ninvoke(task, 'save')
 
       # All ok! So set the result
-      utils.logAndSetResponse this, 'created', "User #{this.authenticated.email} created task with id #{task.id}", 'info'
+      utils.logAndSetResponse this, 201, "User #{this.authenticated.email} created task with id #{task.id}", 'info'
     else
       # rerun task creation not allowed
-      utils.logAndSetResponse this, 'forbidden', "Insufficient permissions prevents this rerun task from being created", 'error'
+      utils.logAndSetResponse this, 403, "Insufficient permissions prevents this rerun task from being created", 'error'
   catch err
     # Error! So inform the user
-    utils.logAndSetResponse this, 'internal server error', "Could not add Task via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not add Task via the API: #{err}", 'error'
 
 
 
@@ -239,12 +239,12 @@ exports.getTask = (taskId) ->
     # Test if the result if valid
     if result == null
       # task not found! So inform the user
-      utils.logAndSetResponse this, 'not found', "We could not find a Task with this ID: #{taskId}.", 'info'
+      utils.logAndSetResponse this, 404, "We could not find a Task with this ID: #{taskId}.", 'info'
     else
       this.body = result
       # All ok! So set the result
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not fetch Task by ID {taskId} via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not fetch Task by ID {taskId} via the API: #{err}", 'error'
 
 
 
@@ -255,7 +255,7 @@ exports.getTask = (taskId) ->
 exports.updateTask = (taskId) ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to updateTask denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to updateTask denied.", 'info'
     return
 
   # Get the values to use
@@ -272,7 +272,7 @@ exports.updateTask = (taskId) ->
     this.body = 'The Task was successfully updated'
     logger.info "User #{this.authenticated.email} updated task with id #{taskId}"
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not update Task by ID {taskId} via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not update Task by ID {taskId} via the API: #{err}", 'error'
 
 
 
@@ -282,7 +282,7 @@ exports.updateTask = (taskId) ->
 exports.removeTask = (taskId) ->
   # Must be admin
   if not authorisation.inGroup 'admin', this.authenticated
-    utils.logAndSetResponse this, 'forbidden', "User #{this.authenticated.email} is not an admin, API access to removeTask denied.", 'info'
+    utils.logAndSetResponse this, 403, "User #{this.authenticated.email} is not an admin, API access to removeTask denied.", 'info'
     return
 
   # Get the values to use
@@ -296,4 +296,4 @@ exports.removeTask = (taskId) ->
     this.body = 'The Task was successfully deleted'
     logger.info "User #{this.authenticated.email} removed task with id #{taskId}"
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not remove Task by ID {taskId} via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not remove Task by ID {taskId} via the API: #{err}", 'error'

--- a/src/api/visualizer.coffee
+++ b/src/api/visualizer.coffee
@@ -7,11 +7,11 @@ exports.getLatestEvents = (receivedTime) ->
     result = yield VisualizerEvent.find({ 'created': { '$gte': rtDate } }).sort({ 'ts': 1 }).exec()
     this.body = events: result
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not fetch the latest visualizer events via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not fetch the latest visualizer events via the API: #{err}", 'error'
 
 exports.sync = (next) ->
   try
     this.body = now: Date.now()
     yield next
   catch err
-    utils.logAndSetResponse this, 'internal server error', "Could not fetch current date via the API: #{err}", 'error'
+    utils.logAndSetResponse this, 500, "Could not fetch current date via the API: #{err}", 'error'

--- a/src/middleware/authorisation.coffee
+++ b/src/middleware/authorisation.coffee
@@ -124,7 +124,7 @@ exports.authorise = (ctx, done) ->
             return done()
 
     # authorisation failed
-    ctx.response.status = "unauthorized"
+    ctx.response.status = 401
     if config.authentication.enableBasicAuthentication
       ctx.set "WWW-Authenticate", "Basic"
     logger.info "The request, '" + ctx.request.path + "', is not authorised to access any channels."

--- a/src/middleware/pollingBypassAuthentication.coffee
+++ b/src/middleware/pollingBypassAuthentication.coffee
@@ -34,5 +34,5 @@ exports.koaMiddleware = (next) ->
     sdc.timing "#{domain}.pollingBypassAuthenticationMiddleware", startTime if statsdServer.enabled
     yield next
   else
-    this.response.status = "unauthorized"
+    this.response.status = 401
     sdc.timing "#{domain}.pollingBypassAuthenticationMiddleware", startTime if statsdServer.enabled

--- a/src/middleware/router.coffee
+++ b/src/middleware/router.coffee
@@ -9,7 +9,6 @@ config = require '../config/config'
 config.mongo = config.get 'mongo'
 config.router = config.get 'router'
 logger = require "winston"
-status = require "http-status"
 cookie = require 'cookie'
 fs = require 'fs'
 utils = require '../utils'
@@ -68,7 +67,7 @@ setCookiesOnContext = (ctx, value) ->
       ctx.cookies.set p_key,p_val,c_opts
 
 handleServerError = (ctx, err) ->
-  ctx.response.status = status.INTERNAL_SERVER_ERROR
+  ctx.response.status = 500
   ctx.response.timestamp = new Date()
   ctx.response.body = "An internal server error occurred"
   logger.error "Internal server error occured: #{err} "
@@ -312,7 +311,7 @@ sendSocketRequest = (ctx, route, options) ->
     if route.secured and not client.authorized
       return defered.reject new Error 'Client authorization failed'
     response.body = Buffer.concat bufs
-    response.status = status.OK
+    response.status = 200
     response.timestamp = new Date()
     if not defered.promise.isRejected()
       defered.resolve response

--- a/src/middleware/tcpBypassAuthentication.coffee
+++ b/src/middleware/tcpBypassAuthentication.coffee
@@ -34,5 +34,5 @@ exports.koaMiddleware = (next) ->
     sdc.timing "#{domain}.tcpBypassAuthenticationMiddleware", startTime if statsdServer.enabled
     yield next
   else
-    this.response.status = "unauthorized"
+    this.response.status = 401
     sdc.timing "#{domain}.tcpBypassAuthenticationMiddleware", startTime if statsdServer.enabled

--- a/src/middleware/visualizer.coffee
+++ b/src/middleware/visualizer.coffee
@@ -65,7 +65,7 @@ addRouteEvents = (dst, route, prefix, tsDiff) ->
     comp: "#{prefix}-#{route.name}"
     ev: 'start'
 
-  routeStatus = 'ok'
+  routeStatus = 200
   if 400 <= route.response.status <= 499
     routeStatus = 'completed'
   else if 500 <= route.response.status <= 599
@@ -115,7 +115,7 @@ storeVisualizerEvents = (ctx, done) ->
     tsDiff = getTsDiff startTS, ctx.mediatorResponse.orchestrations
     addRouteEvents trxEvents, orch, 'orch', tsDiff for orch in ctx.mediatorResponse.orchestrations
 
-  status = 'ok'
+  status = 200
   if ctx.transactionStatus is messageStore.transactionStatus.COMPLETED
     status = 'completed'
   else if ctx.transactionStatus is messageStore.transactionStatus.COMPLETED_W_ERR

--- a/test/integration/e2eIntegrationTests.coffee
+++ b/test/integration/e2eIntegrationTests.coffee
@@ -766,7 +766,7 @@ describe "e2e Integration Tests", ->
     mediatorResponse =
       status: "Successful"
       response:
-        status: "200"
+        status: 200
         headers: {}
         body: "<transaction response>"
         timestamp: 1412257881909
@@ -780,7 +780,7 @@ describe "e2e Integration Tests", ->
           method: "POST"
           timestamp: 1412257881904
         response:
-          status: "200"
+          status: 200
           headers: {}
           body: "<route response>"
           timestamp: 1412257881909
@@ -871,7 +871,7 @@ describe "e2e Integration Tests", ->
       mediatorResponse =
         status: "Successful"
         response:
-          status: "200"
+          status: 200
           headers: {}
           body: "<transaction response>"
           timestamp: 1412257881909
@@ -885,7 +885,7 @@ describe "e2e Integration Tests", ->
             method: "POST"
             timestamp: 1412257881904
           response:
-            status: "200"
+            status: 200
             headers: {}
             body: "<route response>"
             timestamp: 1412257881909

--- a/test/unit/authorisationTest.coffee
+++ b/test/unit/authorisationTest.coffee
@@ -107,7 +107,7 @@ describe "Authorisation middleware", ->
         ctx.set = ->
         authorisation.authorise ctx, ->
           (ctx.authorisedChannel == undefined).should.be.true
-          ctx.response.status.should.be.exactly "unauthorized"
+          ctx.response.status.should.be.exactly 401
           done()
 
     it "should allow a request if the client is authorised to use the channel by clientID", (done) ->


### PR DESCRIPTION
Closes #318 

@rcrichton if you could please take a look? @bausmeier it would be useful if you could take a look as well, seeing as you picked this up originally?

Replaced all the status string with codes. Used ack to figure out what statuses we're using (`ack --type coffeescript -o 'status ?= ?(.*)'`) and a combination of ack and perl to substitute the matches (using the approach outline in the first answer [here](http://stackoverflow.com/questions/4792561/how-to-do-search-replace-with-ack-in-vim)).

I *think* I've got everything. The tests are passing and my test transactions are happy.