### PR TITLE
Fix memory leak

### DIFF
--- a/src/server.coffee
+++ b/src/server.coffee
@@ -271,7 +271,7 @@ else
       httpsServer.on 'clientError', (err) ->
         logger.error "An httpsServer clientError occured: #{err}"
 
-      httpsServer.on 'connection', (socket) -> trackConnection activeHttpsConnections, socket
+      httpsServer.on 'secureConnection', (socket) -> trackConnection activeHttpsConnections, socket
 
     return deferred.promise
 
@@ -318,7 +318,7 @@ else
         logger.info "API HTTPS listening on port " + apiPort
         ensureRootUser -> deferred.resolve()
 
-      apiHttpsServer.on 'connection', (socket) -> trackConnection activeApiConnections, socket
+      apiHttpsServer.on 'secureConnection', (socket) -> trackConnection activeApiConnections, socket
 
     return deferred.promise
 


### PR DESCRIPTION
By comparing heap snapshots I found that references to closed `TLSSocket`s are being retained by the `activeApiConnections` object. After some investigation I found that the close listener that is being added in `trackConnection` is never called. It turns out the reference that is passed to the `connection` event on HTTPS servers is to the underlying `net.Socket` and not to the `TLSSocket` itself. For some reason the `close` event is not emitted on the underlying socket so the listener is never being called and the references aren't being cleaned up. By listening to the `secureConnection` event instead of the `connection` event we get a reference to the `TLSSocket` which does emit the `close` event.