### PR TITLE
Issue #512: Set mongoose to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "koa-route": "^2.4.0",
     "koa-statsd": "^0.0.2",
     "moment": "^2.8.4",
-    "mongoose": "^4.0.1",
+    "mongoose": "4.0.2",
     "nconf": "^0.7.1",
     "node-uuid": "^1.4.1",
     "nodemailer": "^1.3.2",


### PR DESCRIPTION
Closes #512 

Skipping CR as this is just a one liner package fix.