### PR TITLE
Added network bridge setting in updated Vagrant file

### DIFF
--- a/infrastructure/development/env/Vagrantfile
+++ b/infrastructure/development/env/Vagrantfile
@@ -11,6 +11,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.customize ["modifyvm", :id, "--memory", 1536]
   end
 
+  config.vm.network "public_network"
+
   # Configure port forwarding
   config.vm.network "forwarded_port", guest: 5000, host: 5000
   config.vm.network "forwarded_port", guest: 5001, host: 5001


### PR DESCRIPTION
With the updated vagrant file, the bridged connection (eth1) no longer existed.