### PR TITLE
Audit server bug

### DIFF
--- a/infrastructure/development/env/Vagrantfile
+++ b/infrastructure/development/env/Vagrantfile
@@ -11,8 +11,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.customize ["modifyvm", :id, "--memory", 1536]
   end
 
-  config.vm.network "public_network"
-
   # Configure port forwarding
   config.vm.network "forwarded_port", guest: 5000, host: 5000
   config.vm.network "forwarded_port", guest: 5001, host: 5001

--- a/infrastructure/development/env/Vagrantfile
+++ b/infrastructure/development/env/Vagrantfile
@@ -11,6 +11,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.customize ["modifyvm", :id, "--memory", 1536]
   end
 
+  config.vm.network "public_network"
+
   # Configure port forwarding
   config.vm.network "forwarded_port", guest: 5000, host: 5000
   config.vm.network "forwarded_port", guest: 5001, host: 5001

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -431,6 +431,10 @@ else
           # update message to remove length - add one extra character to remove the space
           message = message.substr(lengthIndex + 1)
 
+        if isNaN(length)
+          logger.info "[Auditing #{type}] No length supplied"
+          sock.destroy()
+          
         # if sourced length equals message length then full message received
         if length == message.length
           logger.info "[Auditing #{type}] Received message from #{sock.remoteAddress}"


### PR DESCRIPTION
When send a audit message via TCP or TLS and no length is supplied then the request fails silently.

credit to @bausmeier for tracking down the issue