### PR TITLE
Fixes #545: defaultChannelConfig.name sparse index

### DIFF
--- a/src/model/mediators.coffee
+++ b/src/model/mediators.coffee
@@ -26,6 +26,8 @@ MediatorSchema = new Schema
   "_configModifiedTS":      Date
   "_uptime":                Number
   "_lastHeartbeat":         Date
+
+MediatorSchema.index "defaultChannelConfig.name", sparse: true
  
 # Model for describing a collection of mediators that have registered themselves with core
 exports.Mediator = connectionDefault.model 'Mediator', MediatorSchema


### PR DESCRIPTION
@rcrichton this seems to do the trick. the issue is that the channel schema has a unique index on it, and when mediators haven't got default channel config, a null key was added to this index.