### PR TITLE
Fixes #545: Refactored channels schema definition

### DIFF
--- a/src/model/channels.coffee
+++ b/src/model/channels.coffee
@@ -30,8 +30,8 @@ RewriteRuleDef =
   "toPort":         type: Number, required: true, default: 80
   "pathTransform":  String
 
-ChannelSchema = new Schema
-  "name":               type: String, required: true, unique: true
+ChannelDef =
+  "name":               type: String, required: true
   "description":        String
   "urlPattern":         type: String, required: true
   "type":               type: String, default: 'http', enum: ['http', 'tcp', 'tls', 'polling']
@@ -71,5 +71,8 @@ exports.RouteDef = RouteDef
 # A channel also has an allow property. This property should contain a list
 # of users or group that are authroised to send messages to this channel.
 ###
+ChannelSchema = new Schema ChannelDef
+ChannelSchema.index "name", unique: true
+
 exports.Channel = connectionDefault.model 'Channel', ChannelSchema
-exports.ChannelSchema = ChannelSchema
+exports.ChannelDef = ChannelDef

--- a/src/model/mediators.coffee
+++ b/src/model/mediators.coffee
@@ -3,7 +3,7 @@ server = require "../server"
 connectionDefault = server.connectionDefault
 Schema = mongoose.Schema
 RouteDef = require('./channels').RouteDef
-ChannelSchema = require('./channels').ChannelSchema
+ChannelDef = require('./channels').ChannelDef
 
 exports.configParamTypes = [ 'string', 'bool', 'number', 'option', 'bigstring' ]
 
@@ -21,14 +21,12 @@ MediatorSchema = new Schema
   "name":                   type: String, required: true
   "description":            String
   "endpoints":              [RouteDef]
-  "defaultChannelConfig":   [ChannelSchema]
+  "defaultChannelConfig":   [ChannelDef]
   "configDefs":             [configDef]
   "config":                 Object
   "_configModifiedTS":      Date
   "_uptime":                Number
   "_lastHeartbeat":         Date
-
-MediatorSchema.index "defaultChannelConfig.name", sparse: true
 
 # Model for describing a collection of mediators that have registered themselves with core
 exports.Mediator = connectionDefault.model 'Mediator', MediatorSchema

--- a/test/integration/channelsAPITests.coffee
+++ b/test/integration/channelsAPITests.coffee
@@ -131,6 +131,31 @@ describe "API Integration Tests", ->
                 channel.allow.should.have.length 3
                 done()
 
+      it 'should reject a channel without a name', (done) ->
+        newChannel =
+          urlPattern: "test/sample"
+          allow: [ "PoC", "Test1", "Test2" ]
+          routes: [
+                name: "test route"
+                host: "localhost"
+                port: 9876
+                primary: true
+              ]
+
+        request("https://localhost:8080")
+          .post("/channels")
+          .set("auth-username", testUtils.rootUser.email)
+          .set("auth-ts", authDetails.authTS)
+          .set("auth-salt", authDetails.authSalt)
+          .set("auth-token", authDetails.authToken)
+          .send(newChannel)
+          .expect(400)
+          .end (err, res) ->
+            if err
+              done err
+            else
+              done()
+
       it 'should reject invalid channels with invalid pathTransform', (done) ->
         invalidChannel =
           name: "InvalidChannel"


### PR DESCRIPTION
Closes #545 for real this time

@rcrichton if you could please review? The problem was that the index definition in the channel schema was propagated through to the mediator schema when it reused it - i refactored it a bit so as to keep the index definition out of the channel def. The mediator collection therefore won't even have an index on channel.name anymore, which i think is correct.