### PR TITLE
Mediators: Added support for 'map' config type

### DIFF
--- a/docs/dev-guide/mediators.md
+++ b/docs/dev-guide/mediators.md
@@ -78,6 +78,7 @@ The `configDefs` property defines an array of configuration definitions that eac
 * `bool` - A boolean value (true or false)
 * `number` - An integer or decimal value
 * `option` - A value from a pre-defined list. If this datatype is use then the `values` property MUST also be used. The `values` property specifies an array of possible values for the parameter.
+* `map` - Key/value pairs. A map is formatted as an object with string values, e.g. `{ "key1": "value1", "key2": "value2" }`. New keys can be added dynamically.
 
 The OpenHIM-core SHALL respond with a HTTP status of 201 if the mediator registration was successful.
 The OpenHIM-core SHALL respond with an appropriate 4xx status if the mediator registration could not be completed due to a bad request.

--- a/docs/dev-guide/mediators.md
+++ b/docs/dev-guide/mediators.md
@@ -78,7 +78,7 @@ The `configDefs` property defines an array of configuration definitions that eac
 * `bool` - A boolean value (true or false)
 * `number` - An integer or decimal value
 * `option` - A value from a pre-defined list. If this datatype is use then the `values` property MUST also be used. The `values` property specifies an array of possible values for the parameter.
-* `map` - Key/value pairs. A map is formatted as an object with string values, e.g. `{ "key1": "value1", "key2": "value2" }`. New keys can be added dynamically.
+* `map` - Key/value pairs. A map is formatted as an object with string values, e.g. `{ "key1": "value1", "key2": "value2" }`. New key/value pairs can be added dynamically.
 
 The OpenHIM-core SHALL respond with a HTTP status of 201 if the mediator registration was successful.
 The OpenHIM-core SHALL respond with an appropriate 4xx status if the mediator registration could not be completed due to a bad request.

--- a/src/api/mediators.coffee
+++ b/src/api/mediators.coffee
@@ -181,6 +181,12 @@ validateConfig = (configDef, config) ->
         when 'option'
           if (def.values.indexOf config[param]) is -1
             throw constructError "Expected config param #{param} to be one of #{def.values}", 'ValidationError'
+        when 'map'
+          if typeof config[param] isnt 'object'
+            throw constructError "Expected config param #{param} to be an object.", 'ValidationError'
+          for k, v of config[param]
+            if typeof v isnt 'string'
+              throw constructError "Expected config param #{param} to only contain string values.", 'ValidationError'
     # reduce array of results to a single value
 
 if process.env.NODE_ENV == "test"

--- a/src/model/mediators.coffee
+++ b/src/model/mediators.coffee
@@ -5,7 +5,7 @@ Schema = mongoose.Schema
 RouteDef = require('./channels').RouteDef
 ChannelDef = require('./channels').ChannelDef
 
-exports.configParamTypes = [ 'string', 'bool', 'number', 'option', 'bigstring' ]
+exports.configParamTypes = [ 'string', 'bool', 'number', 'option', 'bigstring', 'map' ]
 
 configDef =
   "param":        String

--- a/test/unit/mediatorsAPITest.coffee
+++ b/test/unit/mediatorsAPITest.coffee
@@ -111,3 +111,76 @@ describe "Mediator API unit tests", ->
         ],
         param1: "test2"
       )
+
+    it "should allow config that includes the 'map' type", ->
+      mediators.validateConfig(
+        [
+          param: "param1"
+          type: "map"
+        ],
+        param1:
+          k1: "v1"
+          k2: "v2"
+      )
+
+    it "should reject config that includes a 'map' that isn't an object", ->
+      try
+        mediators.validateConfig(
+          [
+            param: "param1"
+            type: "map"
+          ],
+          param1: [
+            k1: "v1"
+            k2: "v2"
+          ]
+        )
+      catch err
+        return
+
+      throw new Error 'Failed'
+
+    it "should reject config that includes a 'map' that isn't an object", ->
+      try
+        mediators.validateConfig(
+          [
+            param: "param1"
+            type: "map"
+          ],
+          param1: "blah"
+        )
+      catch err
+        return
+
+    it "should reject config that includes a 'map' with non-string values", ->
+      try
+        mediators.validateConfig(
+          [
+            param: "param1"
+            type: "map"
+          ],
+          param1:
+            k1: "v1"
+            k2: 42
+        )
+      catch err
+        return
+
+      throw new Error 'Failed'
+
+    it "should reject config that includes a 'map' with non-string values", ->
+      try
+        mediators.validateConfig(
+          [
+            param: "param1"
+            type: "map"
+          ],
+          param1:
+            k1: "v1"
+            k2:
+              subK: "blah"
+        )
+      catch err
+        return
+
+      throw new Error 'Failed'

--- a/test/unit/mediatorsAPITest.coffee
+++ b/test/unit/mediatorsAPITest.coffee
@@ -152,7 +152,7 @@ describe "Mediator API unit tests", ->
       catch err
         return
 
-    it "should reject config that includes a 'map' with non-string values", ->
+    it "should reject config that includes a 'map' with non-string values (number)", ->
       try
         mediators.validateConfig(
           [
@@ -168,7 +168,7 @@ describe "Mediator API unit tests", ->
 
       throw new Error 'Failed'
 
-    it "should reject config that includes a 'map' with non-string values", ->
+    it "should reject config that includes a 'map' with non-string values (object)", ->
       try
         mediators.validateConfig(
           [


### PR DESCRIPTION
@rcrichton what do you think?

There's a lot we can do e.g. with regards to the dynamic config for the file queue but I think this map is already really useful and would be great to keep as is. Therefore I think whatever we look into next should be done in addition to this as another config type/plugin architecture/whatever.