### PR TITLE
Fix validation issues during rerun

### DIFF
--- a/src/model/transactions.coffee
+++ b/src/model/transactions.coffee
@@ -25,7 +25,7 @@ ResponseDef =
 OrchestrationMetadataDef =
   "name" :      type: String, required: true
   "group" :     String
-  "request":    RequestDef
+  "request":    type: RequestDef, required: false # this is needed to prevent Validation error, see https://github.com/jembi/openhim-console/issues/356#issuecomment-188708443
   "response":   ResponseDef
 
 # Route Schema


### PR DESCRIPTION
@hnnesv could you please review this for me. Also @napiergit could you have a look and also try out this branch with the transactions that you were having this problem with and let me know if this fixes it for you.

Details:

Mongoose populates object in the schema with empty objects and empty
arrays by default. This causes the request object to be an empty object
even when no request property was even supplied. This then causes
Mongoose's validation to fail as it expects request objects to have a
.timestamp property.

Adding `required: false` to the schema seems to stop Mongoose from
populating it as an empty object.

See https://github.com/jembi/openhim-console/issues/356