### PR TITLE
Changed to relative links for _static resources

### DIFF
--- a/docs/tutorial/1-getting-started.md
+++ b/docs/tutorial/1-getting-started.md
@@ -4,7 +4,7 @@ Tutorial start
 Before getting started with the tutorials, please ensure that
 
 *   the OpenHIM has been installed (see [here](http://127.0.0.1:8000/tutorial/1-getting-started.html#getting-started "What is the easiest way to install the OpenHIM?") for tips on proceeding with this if not done so already)
-*   the [tutorial services](/_static/mediators/openhim-tutorial-services.zip "Tutorial services") are set up and running.
+*   the [tutorial services](../_static/mediators/openhim-tutorial-services.zip "Tutorial services") are set up and running.
 
 The tutorial services consist of three mock health registries that we'll be routing to and retrieving data from during the tutorials. They provide simple endpoints, hosting mock patients, their health records and healthcare providers. Once you've downloaded the services, you will need to open up three terminals so that each service can be started individually. To do so, follow the below steps:
 

--- a/docs/tutorial/3-creating-a-passthrough-mediator.md
+++ b/docs/tutorial/3-creating-a-passthrough-mediator.md
@@ -389,7 +389,7 @@ $ mkdir installCert
 $ cd installCert
 ```
 
-Download the [InstallCert.java.zip](/_static/mediators/InstallCert.java.zip "InstalCert.java.zip") folder and extract the **InstallCert.java** script into our new **installCert** directory. We need to compile our **InstallCert.java** script to generate a **jssecacerts** file for us. Lets start this off by executing the below command which will generate two Java **.class** files for us:
+Download the [InstallCert.java.zip](../_static/mediators/InstallCert.java.zip "InstalCert.java.zip") folder and extract the **InstallCert.java** script into our new **installCert** directory. We need to compile our **InstallCert.java** script to generate a **jssecacerts** file for us. Lets start this off by executing the below command which will generate two Java **.class** files for us:
 
 `$ javac InstallCert.java`
 


### PR DESCRIPTION
Hey @rcrichton looks like the resource links are broken

Not sure if this is the correct way to specify them! This works when I build the docs locally though.

Thanks to @psmatsinhe for pointing these out