### PR TITLE
OHM-243 Apply a factor to setTimeout calls in testing

### DIFF
--- a/src/middleware/events.coffee
+++ b/src/middleware/events.coffee
@@ -48,7 +48,7 @@ getTsDiff = ( ctxStartTS, obj ) ->
 addRouteEvents = (ctx, dst, route, prefix, tsDiff) ->
 
   if route?.request?.timestamp? and route?.response?.timestamp?
-    
+
     startTS = formatTS route.request.timestamp
     endTS = formatTS route.response.timestamp
 

--- a/test/globalConfig.coffee
+++ b/test/globalConfig.coffee
@@ -5,7 +5,7 @@ config = require "../config/test.json"
 global.testTimeoutFactor = 1
 
 if process.env.TRAVIS is 'true'
-  global.testTimeoutFactor = 20
+  global.testTimeoutFactor = 12 # this can be changed to 20  once we have mocha test timeouts of greater than 3s on travis
 
 dropTestDb = (done) ->
   # ensure that we can only drop the test database

--- a/test/globalConfig.coffee
+++ b/test/globalConfig.coffee
@@ -2,6 +2,11 @@ require('source-map-support').install handleUncaughtExceptions: false
 mongoose = require 'mongoose'
 config = require "../config/test.json"
 
+global.testTimeoutFactor = 1
+
+if process.env.TRAVIS is 'true'
+  global.testTimeoutFactor = 20
+
 dropTestDb = (done) ->
   # ensure that we can only drop the test database
   if config.mongo.url.indexOf('openhim-test') > -1

--- a/test/integration/auditingIntegrationTests.coffee
+++ b/test/integration/auditingIntegrationTests.coffee
@@ -38,7 +38,7 @@ describe "Auditing Integration Tests", ->
           done()
 
         # async test :(
-        setTimeout checkAudits, 1000
+        setTimeout checkAudits, 100 * global.testTimeoutFactor
 
   describe "TLS Audit Server", ->
 

--- a/test/integration/e2eIntegrationTests.coffee
+++ b/test/integration/e2eIntegrationTests.coffee
@@ -921,7 +921,7 @@ describe "e2e Integration Tests", ->
                     should.exist res.properties
                     res.properties.orderId.should.be.equal mediatorResponse.properties.orderId
                     done()
-                ), 1500
+                ), 150 * global.testTimeoutFactor
 
   describe "Multipart form data tests", ->
     mockServer = null
@@ -1200,7 +1200,7 @@ describe "e2e Integration Tests", ->
                   trx.routes[0].should.have.property 'name', 'test route 2'
                   trx.routes[0].response.body.should.be.exactly 'target2'
                   done()
-              ), 1500
+              ), 150 * global.testTimeoutFactor
 
     it "should NOT route transactions to disabled routes", (done) ->
       server.start httpPort: 5001, ->
@@ -1219,7 +1219,7 @@ describe "e2e Integration Tests", ->
                   return done err if err
                   trx.routes.length.should.be.exactly 0
                   done()
-              ), 1500
+              ), 150 * global.testTimeoutFactor
 
     it "should ignore disabled primary routes (multiple primary routes)", (done) ->
       server.start httpPort: 5001, ->
@@ -1238,7 +1238,7 @@ describe "e2e Integration Tests", ->
                   return done err if err
                   trx.routes.length.should.be.exactly 0
                   done()
-              ), 1500
+              ), 150 * global.testTimeoutFactor
 
 
   describe "Channel priority tests", ->

--- a/test/integration/logsAPITests.coffee
+++ b/test/integration/logsAPITests.coffee
@@ -43,15 +43,15 @@ describe 'API Integration Tests', ->
                           server.start apiPort: 8080, ->
                             done()
                             # We need to go deeper!
-                      , 50 * global.testTimeoutFactor
-                    , 50 * global.testTimeoutFactor
-                  , 50 * global.testTimeoutFactor
-                , 50 * global.testTimeoutFactor
-              , 50 * global.testTimeoutFactor
-            , 50 * global.testTimeoutFactor
-          , 50 * global.testTimeoutFactor
-        , 50 * global.testTimeoutFactor
-      , 50 * global.testTimeoutFactor
+                      , 15 * global.testTimeoutFactor
+                    , 15 * global.testTimeoutFactor
+                  , 15 * global.testTimeoutFactor
+                , 15 * global.testTimeoutFactor
+              , 15 * global.testTimeoutFactor
+            , 15 * global.testTimeoutFactor
+          , 15 * global.testTimeoutFactor
+        , 15 * global.testTimeoutFactor
+      , 15 * global.testTimeoutFactor
 
     after (done) ->
       logger.transports.MongoDB.level = 'debug'

--- a/test/integration/logsAPITests.coffee
+++ b/test/integration/logsAPITests.coffee
@@ -43,15 +43,15 @@ describe 'API Integration Tests', ->
                           server.start apiPort: 8080, ->
                             done()
                             # We need to go deeper!
-                      , 50
-                    , 50
-                  , 50
-                , 50
-              , 50
-            , 50
-          , 50
-        , 50
-      , 50
+                      , 50 * global.testTimeoutFactor
+                    , 50 * global.testTimeoutFactor
+                  , 50 * global.testTimeoutFactor
+                , 50 * global.testTimeoutFactor
+              , 50 * global.testTimeoutFactor
+            , 50 * global.testTimeoutFactor
+          , 50 * global.testTimeoutFactor
+        , 50 * global.testTimeoutFactor
+      , 50 * global.testTimeoutFactor
 
     after (done) ->
       logger.transports.MongoDB.level = 'debug'

--- a/test/integration/transactionsAPITests.coffee
+++ b/test/integration/transactionsAPITests.coffee
@@ -47,7 +47,7 @@ describe "API Integration Tests", ->
       channelID: "888888888888888888888888"
       request: requ
       response: respo
-        
+
       routes:
         [
           name: "dummy-route"
@@ -61,7 +61,7 @@ describe "API Integration Tests", ->
           request: requ
           response: respo
         ]
-      properties: 
+      properties:
         "prop1": "prop1-value1"
         "prop2": "prop-value1"
 
@@ -178,7 +178,7 @@ describe "API Integration Tests", ->
                 for ev in events
                   ev.channelID.toString().should.be.exactly channel._id.toString()
                 done()
-            setTimeout validateEvents, 1000
+            setTimeout validateEvents, 100 * global.testTimeoutFactor
 
     describe "*updateTransaction()", ->
 
@@ -189,7 +189,7 @@ describe "API Integration Tests", ->
 
       afterEach ->
         s.stop()
-      
+
       it "should call /updateTransaction ", (done) ->
         tx = new Transaction transactionData
         tx.save (err, result) ->
@@ -338,7 +338,7 @@ describe "API Integration Tests", ->
                   eventRoutes.should.containEql 'route'
                   eventRoutes.should.containEql 'orchestration'
                   done()
-              setTimeout validateEvents, 1000
+              setTimeout validateEvents, 100 * global.testTimeoutFactor
 
     describe "*getTransactions()", ->
 
@@ -367,7 +367,7 @@ describe "API Integration Tests", ->
         obj =
           filterPage: 0
           filterLimit: 10
-          filters: 
+          filters:
             'status': 'Processing'
             'request.timestamp': '{"$gte": "2014-06-09T00:00:00.000Z", "$lte": "2014-06-10T00:00:00.000Z" }'
             'request.path': '/api/test'
@@ -405,13 +405,13 @@ describe "API Integration Tests", ->
         obj =
           filterPage: 0
           filterLimit: 10
-          filters: 
+          filters:
             'status': 'Processing'
             'routes.request.path': '/api/test'
             'routes.response.status': '2xx'
             'orchestrations.request.path': '/api/test'
             'orchestrations.response.status': '2xx'
-            'properties': 
+            'properties':
               'prop1': 'prop1-value1'
 
         params = ""
@@ -446,13 +446,13 @@ describe "API Integration Tests", ->
         obj =
           filterPage: 0
           filterLimit: 10
-          filters: 
+          filters:
             'status': 'Processing'
             'routes.request.path': '/api/test'
             'routes.response.status': '2xx'
             'orchestrations.request.path': '/api/test'
             'orchestrations.response.status': '2xx'
-            'properties': 
+            'properties':
               'prop3': 'prop3-value3'
 
         params = ""

--- a/test/unit/routerTest.coffee
+++ b/test/unit/routerTest.coffee
@@ -230,7 +230,7 @@ describe "HTTP Router", ->
                 ctx.routes[1].request.path.should.be.exactly "/test/multicasting"
                 ctx.routes[1].request.timestamp.should.be.exactly requestTimestamp
                 done()
-              ), 1000
+              ), 100 * global.testTimeoutFactor
 
 
     it "should pass an error to next if there are multiple primary routes", (done) ->
@@ -494,7 +494,7 @@ describe "HTTP Router", ->
                 done()
               catch err
                 done err
-            ), 500
+            ), 50 * global.testTimeoutFactor
 
     it "should set mediator response location header if present and status is not 3xx", (done) ->
       mediatorResponse =

--- a/test/unit/tasksTest.coffee
+++ b/test/unit/tasksTest.coffee
@@ -114,7 +114,7 @@ describe "Rerun Task Tests", ->
 
 
     it 'should run rerunSetHTTPRequestOptions() and return error if no Transaction object supplied', (done) ->
-    
+
       taskID = '53c4dd063b8cb04d2acf0adc'
       transaction = null
       tasks.rerunSetHTTPRequestOptions transaction, taskID, (err, options) ->
@@ -149,7 +149,7 @@ describe "Rerun Task Tests", ->
 
 
     it 'should run rerunHttpRequestSend() and fail when "options" is null', (done) ->
-    
+
       transactionID = "53bfbccc6a2b417f6cd14871"
       Transaction.findOne { _id: transactionID }, (err, transaction) ->
 
@@ -161,7 +161,7 @@ describe "Rerun Task Tests", ->
 
 
     it 'should run rerunHttpRequestSend() and fail when "transaction" is null', (done) ->
-    
+
       options = {}
       options.hostname = "localhost"
       options.port = 7786
@@ -228,7 +228,7 @@ describe "Rerun Task Tests", ->
             server.close ->
               done()
 
-        setTimeout validateTask, 1000
+        setTimeout validateTask, 100 * global.testTimeoutFactor
 
     it 'should process X transactions where X is the batch size', (done) ->
       Task.update { _id: task1._id }, { batchSize: 2 }, (err) ->
@@ -247,7 +247,7 @@ describe "Rerun Task Tests", ->
               server.close ->
                 done()
 
-          setTimeout validateTask, 1000
+          setTimeout validateTask, 100 * global.testTimeoutFactor
 
     it 'should complete a queued task after all its transactions are finished', (done) ->
       Task.update { _id: task1._id }, { batchSize: 3 }, (err) ->
@@ -266,7 +266,7 @@ describe "Rerun Task Tests", ->
               server.close ->
                 done()
 
-          setTimeout validateTask, 1000
+          setTimeout validateTask, 100 * global.testTimeoutFactor
 
     it 'should not process a paused task', (done) ->
       Task.update { _id: task1._id }, { status: 'Paused' }, (err) ->
@@ -285,7 +285,7 @@ describe "Rerun Task Tests", ->
               server.close ->
                 done()
 
-          setTimeout validateTask, 1000
+          setTimeout validateTask, 100 * global.testTimeoutFactor
 
     it 'should not process a cancelled task', (done) ->
       Task.update { _id: task1._id }, { status: 'Cancelled' }, (err) ->
@@ -304,4 +304,4 @@ describe "Rerun Task Tests", ->
               server.close ->
                 done()
 
-          setTimeout validateTask, 1000
+          setTimeout validateTask, 100 * global.testTimeoutFactor

--- a/test/unit/upgradeDBTest.coffee
+++ b/test/unit/upgradeDBTest.coffee
@@ -19,7 +19,7 @@ describe 'Upgrade DB Tests', ->
         else
           func1Complete = true
           defer.resolve()
-      , 10
+      , 10 * global.testTimeoutFactor
       return defer.promise
 
     mockUpgradeFunc2 = () ->


### PR DESCRIPTION
The factor is increased when travis is detected to be running the tests.
This allows us to have quick setTimeout values when testing locally,
however, these are dilated when run on travis. Travis is slower due to
it being a virtual environment.