### PR TITLE
Metrics: timestamp fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "koa-request": "^1.0.0",
     "koa-route": "^2.4.2",
     "koa-statsd": "^0.0.2",
+    "lodash": "^4.14.0",
     "moment": "^2.12.0",
     "mongoose": "^4.4.18",
     "nconf": "^0.8.4",

--- a/src/api/metrics.coffee
+++ b/src/api/metrics.coffee
@@ -6,6 +6,7 @@ mongoose = require 'mongoose'
 authorisation = require './authorisation'
 Q = require 'q'
 metrics = require "../metrics"
+_ = require 'lodash'
 
 # all in one getMetrics generator function for metrics API
 exports.getMetrics = (groupChannels, timeSeries, channelID) ->
@@ -32,7 +33,7 @@ exports.getMetrics = (groupChannels, timeSeries, channelID) ->
 
   if m[0]?._id?.year? # if there are time components
     m = m.map (item) ->
-      date = Object.assign {}, item._id
+      date = _.assign {}, item._id
       # adapt for moment (month starting at 0)
       if date.month then date.month = date.month - 1
       item.timestamp = moment(date)

--- a/src/api/metrics.coffee
+++ b/src/api/metrics.coffee
@@ -32,7 +32,10 @@ exports.getMetrics = (groupChannels, timeSeries, channelID) ->
 
   if m[0]?._id?.year? # if there are time components
     m = m.map (item) ->
-      item.timestamp = moment(item._id)
+      date = Object.assign {}, item._id
+      # adapt for moment (month starting at 0)
+      if date.month then date.month = date.month - 1
+      item.timestamp = moment(date)
       return item
 
   this.body = m


### PR DESCRIPTION
@rcrichton a quick bug fix - seems moment (annoyingly) starts months on 0, so the timestamps were one month ahead in the results.