### PR TITLE
Vagrant: add krb-dev dependency

### DIFF
--- a/infrastructure/development/env/openhim-core-js.pp
+++ b/infrastructure/development/env/openhim-core-js.pp
@@ -15,6 +15,10 @@ package { "build-essential":
     ensure => "installed",
 }
 
+package { "libkrb5-dev":
+    ensure => "installed",
+}
+
 package { "git":
     ensure => "installed",
 }


### PR DESCRIPTION
@rcrichton a quick one - this just adds a build dep so that the native kerberos module compiles correctly (mongodb)