### PR TITLE
Packaging: Include build deps in recommends

### DIFF
--- a/packaging/targets/trusty/debian/control
+++ b/packaging/targets/trusty/debian/control
@@ -10,6 +10,6 @@ Homepage: http://www.openhim.org/
 Package: openhim-core-js
 Architecture: amd64
 Depends: curl, mongodb-org, git
-Recommends:
+Recommends: build-essential, libkrb5-dev
 Description: OpenHIM Core
  The Open Health Information Mediator (OpenHIM) is a middleware software component designed to ease interoperability between disparate information systems. It provides a security communications and data governance as well as support for routing, orchestrating and translating messages as they flow between systems. The HIM can be though of as the "lock" within a health information exchange.


### PR DESCRIPTION
@rcrichton I added them as recommends rather depends. Install recommends is true by default anyway and this at least gives the option for implementers who for some reason don't want to enable native compiling.