### PR TITLE
OHM-336 Fix tz returned for metrics

### DIFF
--- a/docs/dev-guide/api-ref.md
+++ b/docs/dev-guide/api-ref.md
@@ -653,7 +653,7 @@ The metrics API always returns a JSON array, even if it is returning just one me
      channelID: '222222222222222222222222', // Only if breaking down by channels
      day: 15,  // Only the approporiate time components will be returned when
      week: 28, // breaking down in time series, these will not appear if not
-     month: 7, // breaking down by time series.
+     month: 7, // breaking down by time series. These are always UTC values.
      year: 2014
     },
   total: 1,
@@ -954,7 +954,7 @@ An example visualizer object conforming to the [visualizer schema](https://githu
 
 `GET /visualizers`
 
-This request will return a `200` response code and an array of visualizer objects. 
+This request will return a `200` response code and an array of visualizer objects.
 
 #### Fetch a specific visualizer by mongo id
 

--- a/src/api/metrics.coffee
+++ b/src/api/metrics.coffee
@@ -36,7 +36,7 @@ exports.getMetrics = (groupChannels, timeSeries, channelID) ->
       date = _.assign {}, item._id
       # adapt for moment (month starting at 0)
       if date.month then date.month = date.month - 1
-      item.timestamp = moment(date)
+      item.timestamp = moment.utc(date)
       return item
 
   this.body = m


### PR DESCRIPTION
Mongodb always returns time values as UTC.