### PR TITLE
Ohm 368 - Added Filewatcher and server restart functionaility

### DIFF
--- a/docs/user-guide/polling-channels.md
+++ b/docs/user-guide/polling-channels.md
@@ -22,3 +22,5 @@ in cron format (ie. 0 4 * * * ) or in a descriptive format (ie. 5 minutes). See
 for a more complete description of this format. From there you may configure the
 rest of the channel as usual and add routes for each external system that is to
 be triggered.
+
+**NB** When using cron format, it is important to note that the servers' timezone will be used to action the trigger

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "atna-audit": "^0.5.0",
     "basic-auth": "^1.0.0",
     "bcryptjs": "^2.0.0",
+    "chokidar": "^1.6.0",
     "co": "^4.1.0",
     "cookie": "^0.3.1",
     "email-templates": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "koa-statsd": "^0.0.2",
     "lodash": "^4.14.0",
     "moment": "^2.12.0",
+    "moment-timezone": "^0.5.5",
     "mongoose": "^4.4.18",
     "nconf": "^0.8.4",
     "node-uuid": "^1.4.1",

--- a/src/api/about.coffee
+++ b/src/api/about.coffee
@@ -6,7 +6,7 @@ utils = require '../utils'
 exports.getAboutInformation = () ->
   
   try
-    this.body = yield { currentCoreVersion: currentCoreVersion }
+    this.body = yield { currentCoreVersion: currentCoreVersion, serverTimezone: utils.serverTimezone() }
     this.status = 200
     logger.info "User #{this.authenticated.email} successfully fetched 'about' information"
   catch e

--- a/src/api/metadata.coffee
+++ b/src/api/metadata.coffee
@@ -3,6 +3,7 @@ Client = require('../model/clients').Client
 Mediator = require('../model/mediators').Mediator
 User = require('../model/users').User
 ContactGroup = require('../model/contactGroups').ContactGroup
+Keystore = require('../model/keystore').Keystore
 
 Q = require 'q'
 logger = require 'winston'
@@ -16,6 +17,7 @@ collections =
   Mediators: Mediator
   Users: User
   ContactGroups: ContactGroup
+  Keystore: Keystore
 
 
 #Function to remove properties from export object
@@ -95,9 +97,14 @@ handleMetadataPost = (action, that) ->
           if key not of collections
             throw new Error "Invalid Collection in Import Object"
           
-          uidObj = getUniqueIdentifierForCollection key, doc
-          uid = uidObj[Object.keys(uidObj)[0]]
-          result = yield collections[key].find(uidObj).exec()
+          # Keystore model does not have a uid other than _id and may not contain more than one entry
+          if key is 'Keystore'
+            result = yield collections[key].find().exec()
+            uid = ''
+          else
+            uidObj = getUniqueIdentifierForCollection key, doc
+            uid = uidObj[Object.keys(uidObj)[0]]
+            result = yield collections[key].find(uidObj).exec()
           
           if action is 'import'
             if result and result.length > 0 and result[0]._id

--- a/src/certificateWatcher.coffee
+++ b/src/certificateWatcher.coffee
@@ -1,0 +1,41 @@
+logger = require "winston"
+moment = require 'moment'
+chokidar = require 'chokidar'
+server = require "./server"
+
+restartTheServer = (agenda, job, done) ->
+  server.startRestartServerTimeout ->
+    logger.info 'Proceeding to restart servers...'
+
+setupAgenda = (agenda, certificateManagement) ->
+  # cancel any existing agenda job from previous restarts
+  agenda.cancel { name: 'restart the server' }, (err, numRemoved) ->
+    logger.info 'Agenda - Server restart job removed'
+
+  #define agenda job to execute
+  agenda.define 'restart the server', (job, done) -> restartTheServer agenda, job, done
+
+  # certFile = certificateManagement.certPath
+  # keyFile = certificateManagement.keyPath
+  certFile = '/openhim-core-js/resources/certsTest/default/cert.pem'
+  keyFile = '/openhim-core-js/resources/certsTest/default/key.pem'
+  paths = [certFile, keyFile]
+  watcher = chokidar.watch(paths, {
+    usePolling: true,
+    interval: 10000,
+  }).on('ready', ->
+    logger.info 'Certificate/Key watch paths:', watcher.getWatched()
+
+    watcher.on 'change', (path, stats) ->
+      if stats
+        # every - ensure only single job is created
+        agenda.every '1 minutes', 'restart the server', null, ->
+          logger.info 'Certificate/Key has been updated, restart the server'
+      return
+  )
+
+
+exports.setupAgenda = setupAgenda
+
+if process.env.NODE_ENV is "test"
+  exports.restartTheServer = restartTheServer

--- a/src/certificateWatcher.coffee
+++ b/src/certificateWatcher.coffee
@@ -15,10 +15,8 @@ setupAgenda = (agenda, certificateManagement) ->
   #define agenda job to execute
   agenda.define 'restart the server', (job, done) -> restartTheServer agenda, job, done
 
-  # certFile = certificateManagement.certPath
-  # keyFile = certificateManagement.keyPath
-  certFile = '/openhim-core-js/resources/certsTest/default/cert.pem'
-  keyFile = '/openhim-core-js/resources/certsTest/default/key.pem'
+  certFile = certificateManagement.certPath
+  keyFile = certificateManagement.keyPath
   paths = [certFile, keyFile]
   watcher = chokidar.watch(paths, {
     usePolling: true,
@@ -33,7 +31,6 @@ setupAgenda = (agenda, certificateManagement) ->
           logger.info 'Certificate/Key has been updated, restart the server'
       return
   )
-
 
 exports.setupAgenda = setupAgenda
 

--- a/src/polling.coffee
+++ b/src/polling.coffee
@@ -5,8 +5,8 @@ config = require './config/config'
 config.polling = config.get('polling')
 logger = require 'winston'
 Q = require 'q'
-logger = require 'winston'
 authorisation = require './middleware/authorisation'
+utils = require './utils'
 
 exports.agendaGlobal = null
 
@@ -28,7 +28,7 @@ exports.registerPollingChannel = (channel, callback) ->
       request options, ->
         done()
 
-    exports.agendaGlobal.every channel.pollingSchedule, "polling-job-#{channel._id}"
+    exports.agendaGlobal.every channel.pollingSchedule, "polling-job-#{channel._id}", null, { timezone: utils.serverTimezone() }
 
     callback null
 

--- a/src/reports.coffee
+++ b/src/reports.coffee
@@ -11,6 +11,7 @@ config.reports = config.get('reports')
 contact = require './contact'
 metrics = require './metrics'
 User = require('./model/users').User
+utils = require './utils'
 
 # Function Sends the reports
 sendReports = (job, flag, done) ->
@@ -203,8 +204,8 @@ setupAgenda = (agenda) ->
   agenda.define 'send daily channel metrics', (job, done) ->
     sendReports job, 'dailyReport', done
 
-  agenda.every config.reports.weeklyReportAt, 'send weekly channel metrics'
-  agenda.every config.reports.dailyReportAt, 'send daily channel metrics'
+  agenda.every config.reports.weeklyReportAt, 'send weekly channel metrics', null, { timezone: utils.serverTimezone() }
+  agenda.every config.reports.dailyReportAt, 'send daily channel metrics', null, { timezone: utils.serverTimezone() }
 
 
 exports.setupAgenda = setupAgenda

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -58,6 +58,7 @@ auditing = require './auditing'
 tasks = require './tasks'
 upgradeDB = require './upgradeDB'
 autoRetry = require './autoRetry'
+certificateWatcher = require './certificateWatcher'
 
 clusterArg = nconf.get 'cluster'
 
@@ -238,6 +239,7 @@ else
       alerts.setupAgenda agenda if config.alerts.enableAlerts
       reports.setupAgenda agenda if config.reports.enableReports
       autoRetry.setupAgenda agenda
+      certificateWatcher.setupAgenda agenda, config.certificateManagement
       if config.polling.enabled
         polling.setupAgenda agenda, ->
           # give workers a change to setup agenda tasks

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -97,7 +97,7 @@ if cluster.isMaster and not module.parent
 
     worker.on 'message', (msg) ->
 
-      logger.debug "Message recieved from worker #{worker.id}", msg
+      logger.debug "Message received from worker #{worker.id}", msg
       if msg.type is 'restart-all'
         # restart all workers
         logger.debug "Restarting all workers..."

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -239,7 +239,7 @@ else
       alerts.setupAgenda agenda if config.alerts.enableAlerts
       reports.setupAgenda agenda if config.reports.enableReports
       autoRetry.setupAgenda agenda
-      certificateWatcher.setupAgenda agenda, config.certificateManagement
+      certificateWatcher.setupAgenda agenda, config.certificateManagement if config.certificateManagement.watchFSForCert
       if config.polling.enabled
         polling.setupAgenda agenda, ->
           # give workers a change to setup agenda tasks

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -3,6 +3,7 @@ config = require './config/config'
 config.caching = config.get('caching')
 Channel = require("./model/channels").Channel
 Keystore = require("./model/keystore").Keystore
+momentTZ = require 'moment-timezone'
 
 # function to log errors and return response
 exports.logAndSetResponse = (ctx, status, msg, logLevel) ->
@@ -65,3 +66,7 @@ exports.uniqArray = (arr) ->
 
 # thanks to https://coffeescript-cookbook.github.io/chapters/arrays/check-type-is-array
 exports.typeIsArray = Array.isArray || ( value ) -> return {}.toString.call( value ) is '[object Array]'
+
+# get the server timezone
+exports.serverTimezone = () ->
+  return momentTZ.tz.guess()

--- a/test/unit/utilsTest.coffee
+++ b/test/unit/utilsTest.coffee
@@ -19,3 +19,8 @@ describe "Utils", ->
       result = utils.statusCodePatternMatch '200'
       result.should.be.false
       done()
+
+    it "should return server timezone", (done) ->
+      result = utils.serverTimezone()
+      should.exist(result)
+      done()


### PR DESCRIPTION
The PR looks up config variables for certificate management and determines if it should enable the file watcher. If the certificate/key is changed, the agenda task is kciked off to restart the server with the new certificate/key. 

This PR depends on https://github.com/jembi/openhim-core-js/pull/812