### PR TITLE
Fix configuration of router timeout using an environment variable

### DIFF
--- a/src/middleware/router.coffee
+++ b/src/middleware/router.coffee
@@ -351,7 +351,7 @@ sendHttpRequest = (ctx, route, options) ->
 
   routeReq.on "clientError", (err) -> defered.reject err
 
-  routeReq.setTimeout config.router.timeout, -> defered.reject "Request Timed Out"
+  routeReq.setTimeout +config.router.timeout, -> defered.reject "Request Timed Out"
 
   if ctx.request.method == "POST" || ctx.request.method == "PUT"
     routeReq.write ctx.body

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -273,7 +273,7 @@ else
     httpServer = http.createServer app.callback()
 
     # set the socket timeout
-    httpServer.setTimeout config.router.timeout, ->
+    httpServer.setTimeout +config.router.timeout, ->
       logger.info "HTTP socket timeout reached"
 
     httpServer.listen httpPort, bindAddress, ->
@@ -301,7 +301,7 @@ else
       httpsServer = https.createServer options, app.callback()
 
       # set the socket timeout
-      httpsServer.setTimeout config.router.timeout, ->
+      httpsServer.setTimeout +config.router.timeout, ->
         logger.info "HTTPS socket timeout reached"
 
       httpsServer.listen httpsPort, bindAddress, ->


### PR DESCRIPTION
The OpenHIM crashed when using an environment variable to configure the router timeout because the value is a string.

To reproduce start the OpenHIM with `router_timeout=120000 npm start` and make a request to the router.

Casting the config value to a number fixes the problem.