### PR TITLE
Fix config.md docs

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -33,10 +33,10 @@ The following config option are provided by the OpenHIM. All of these options ha
     // The external hostname of the OpenHIM, used to rewrite urls in http responses
     "externalHostname": "localhost"
     // This is the port that the OpenHIM will receive HTTP request on to
-    // them to other services
+    // forward them to other services
     "httpPort": 5001,
     // This is the port that the OpenHIM will receive HTTPS request on to
-    // them to other services
+    // forward  them to other services
     "httpsPort": 5000,
     // The timeout for requests that the OpenHIM makes to other services (in milliseconds)
     "timeout": 60000


### PR DESCRIPTION
The config.md file has two typos in the description for
"router.httpsPort" and "router.httpPort". I have added the missing
word("forward") in both descriptions.