### PR TITLE
Fix environment reading in config

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -11,7 +11,10 @@ export const appRoot = path.resolve(__dirname, '../..')
 function Config () {
   // Get the argument-value to use
   nconf.argv().env('_')
-  const environment = nconf.get('NODE:ENV')
+
+  // don't read NODE:ENV from nconf as it could be overwritten by any env var starting with 'NODE_'
+  const environment = process.env.NODE_ENV
+
   const conf = nconf.get('conf')
 
   // Load the configuration-values


### PR DESCRIPTION
Sometimes, depending on environment variable order, the NODE:ENV key in
nconf was being overwritten by a NODE environment variable. This was
happening particularly in workers. This is probably why nconf uses ':'
as a separator instead of '_' which we are using. Changing to not use
'_' would introduce breaking changes so this change rather reads the
environment directly from process.env.