### PR TITLE
Update the URL to the Roadmap on the WIKI

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,3 @@
 # OpenHIM Roadmap 2019
 
-Please see our [confluence page](https://jembiprojects.jira.com/wiki/spaces/OHI/pages/598802437/Open-HIM+Roadmap)
- for details.
+Please see our [wiki](https://github.com/jembi/openhim-core-js/wiki/OpenHIM-core-Development-Roadmap)


### PR DESCRIPTION
Users can't get to the old URL on the confluence unless they are part of Jembi...