### PR TITLE
OHM-764 Add transformations to add/remove message body from transactions

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -18,7 +18,7 @@ async function composeTransaction (transaction, body) {
 // Should save the body into GridFS directly
 // Should still return the body in the result
 async function decomposeTransaction (transaction) {
-  const body = transaction.body
+  const body = Object.assign({}, transaction.body)
   const debodied = transaction
   debodied.body = ''
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,0 +1,34 @@
+import logger from 'winston'
+
+import { config } from './config'
+
+// TODO 
+// Should lookup the body from GridFS based solely on the transaction ID
+// No need to pass 'body' as a parm
+async function composeTransaction (transaction, body) {
+  const newTransaction = transaction
+  newTransaction.body = body
+
+  logger.info(`Added body to transaction #${newTransaction._id}`)
+
+  return newTransaction
+}
+
+// TODO 
+// Should save the body into GridFS directly
+// Should still return the body in the result
+async function decomposeTransaction (transaction) {
+  const body = transaction.body
+  const debodied = transaction
+  debodied.body = ''
+
+  logger.info(`Removed body from transaction #${transaction._id}`)
+
+  return { 
+    transaction: debodied,
+    body 
+  }
+}
+
+exports.composeTransaction = composeTransaction
+exports.decomposeTransaction = decomposeTransaction

--- a/test/unit/transformTest.js
+++ b/test/unit/transformTest.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+
+import * as transform from '../../src/transform'
+
+describe('Transform transactions Tests', () => {
+  it('should decompose a transaction into message and body', async () => {
+    const transaction = {
+      _id: '5cac9a80ae98b3bc0085bf05',
+      body: { 
+        msg: 'Test' 
+      }
+    }
+    const result = await transform.decomposeTransaction(transaction)
+    result.should.have.property('transaction', result.transaction)
+    result.should.have.property('body', result.body)
+  })
+
+  it('should compose a transaction from message and body', async () => {
+    const id = '5cac9a8f274d497474508375'
+    const transaction = {
+      _id: id
+    }
+    const body = { msg: 'Test' }
+    const result = await transform.composeTransaction(transaction, body)
+    result.should.have.property('_id', result._id)
+    result.should.have.property('body', result.body)
+  })
+})

--- a/test/unit/transformTest.js
+++ b/test/unit/transformTest.js
@@ -13,6 +13,7 @@ describe('Transform transactions Tests', () => {
     const result = await transform.decomposeTransaction(transaction)
     result.should.have.property('transaction', result.transaction)
     result.should.have.property('body', result.body)
+    should.equal(result.transaction.body, '')
   })
 
   it('should compose a transaction from message and body', async () => {
@@ -24,5 +25,6 @@ describe('Transform transactions Tests', () => {
     const result = await transform.composeTransaction(transaction, body)
     result.should.have.property('_id', result._id)
     result.should.have.property('body', result.body)
+    should.equal(result.body, body)
   })
 })


### PR DESCRIPTION
Prior to this change, message bodies were held in memory.

This change will persist message bodies to GridFS or retrieve the
bodies and recreate a complete in-memory transaction.

OHM-764 OHM-690