### PR TITLE
create a function for sending an http request

### DIFF
--- a/src/middleware/messageStore.js
+++ b/src/middleware/messageStore.js
@@ -176,18 +176,6 @@ export function initiateResponse (ctx, done) {
     error: ctx.error
   }
 
-  if (ctx.mediatorResponse) {
-    if (ctx.mediatorResponse.orchestrations) {
-      update.orchestrations.push(...ctx.mediatorResponse.orchestrations)
-    }
-
-    if (ctx.mediatorResponse.properties) { update.properties = ctx.mediatorResponse.properties }
-  }
-
-  if (ctx.orchestrations) {
-    update.orchestrations.push(...ctx.orchestrations)
-  }
-
   //await extractTransactionPayloadIntoChunks(update)
   transactions.TransactionModel.findByIdAndUpdate(transactionId, update, { runValidators: true }, (err, tx) => {
     if (err) {
@@ -218,8 +206,27 @@ export function completeResponse (ctx, done) {
   const update = {
     'response.timestampEnd': ctx.responseTimestampEnd,
     'response.status': ctx.response.status,
-    'response.headers': headers,
-    orchestrations: ctx.orchestrations
+    'response.headers': headers
+  }
+
+  if (ctx.mediatorResponse) {
+    if (ctx.mediatorResponse.orchestrations) {
+      if (!update.orchestrations) {
+        update.orchestrations = []
+      }
+      update.orchestrations.push(...ctx.mediatorResponse.orchestrations)
+    }
+
+    if (ctx.mediatorResponse.properties) {
+      update.properties = ctx.mediatorResponse.properties
+    }
+  }
+
+  if (ctx.orchestrations) {
+    if (!update.orchestrations) {
+        update.orchestrations = []
+      }
+    update.orchestrations.push(...ctx.orchestrations)
   }
 
   return transactions.TransactionModel.findByIdAndUpdate(transactionId, update, {runValidators: true}, (err, tx) => {

--- a/src/middleware/router.js
+++ b/src/middleware/router.js
@@ -526,6 +526,7 @@ function sendHttpRequest (ctx, route, options) {
       })
       .on('error', (err) => {
         ctx.primaryRouteFailure = true
+        messageStore.initiateResponse(ctx, () => {})
         logger.error(`Error streaming response upstream: ${err}`)
         reject(err)
       })

--- a/src/middleware/router.js
+++ b/src/middleware/router.js
@@ -523,7 +523,7 @@ function sendHttpRequest (ctx, route, options) {
 
     downstream
       .on('data', (chunk) => {
-        if (['POST', 'PUT'].includes(ctx.request.method)) {
+        if (['POST', 'PUT', 'PATCH'].includes(ctx.request.method)) {
           routeReq.write(chunk)
         }
       })

--- a/src/middleware/router.js
+++ b/src/middleware/router.js
@@ -646,6 +646,9 @@ const sendSecondaryRouteHttpRequest = (ctx, route, options) => {
           if (['POST', 'PUT', 'PATCH'].includes(ctx.request.method)) {
             routeReq.write(chunk)
           }
+          if (ctx.primaryRouteFailure) {
+            routeReq.destroy(new Error(`Aborting secondary route request, primary route request failed`))
+          }
         })
         .on('end', () => {
           routeReq.end()


### PR DESCRIPTION
This is the function that will be used for sending secondary routes requests. It uses some of the functionality that is used in the function for sending the primary route requests. Refactoring will be done later on to apply the DRY principle. The function has been added to the 'sendRequest' function, which is the wrapper for the functions that send the requests. A flag has been added to use the function for secondary routes when route is secondary.

OHM-800