### PR TITLE
Bug fix: Responses in Mediator format was failing the transaction

### DIFF
--- a/src/middleware/router.js
+++ b/src/middleware/router.js
@@ -221,11 +221,11 @@ function sendRequestToRoutes (ctx, routes, next) {
             if (response.headers != null && response.headers['content-type'] != null && response.headers['content-type'].indexOf('application/json+openhim') > -1) {
               // handle mediator reponse
               let payload = ''
-              response.body.on('data',function(data){
+              response.body.on('data', (data) => {
                 payload += data.toString()
               })
 
-              response.body.on('end',function(){
+              response.body.on('end', () => {
                 const responseObj = JSON.parse(payload)
                 ctx.mediatorResponse = responseObj
 

--- a/src/middleware/router.js
+++ b/src/middleware/router.js
@@ -220,15 +220,23 @@ function sendRequestToRoutes (ctx, routes, next) {
             logger.info(`executing primary route : ${route.name}`)
             if (response.headers != null && response.headers['content-type'] != null && response.headers['content-type'].indexOf('application/json+openhim') > -1) {
               // handle mediator reponse
-              const responseObj = JSON.parse(response.body)
-              ctx.mediatorResponse = responseObj
+              let payload = ''
+              response.body.on('data',function(data){
+                payload += data.toString()
+              })
 
-              if (responseObj.error != null) {
-                ctx.autoRetry = true
-                ctx.error = responseObj.error
-              }
-              // then set koa response from responseObj.response
-              setKoaResponse(ctx, responseObj.response)
+              response.body.on('end',function(){
+                const responseObj = JSON.parse(payload)
+                ctx.mediatorResponse = responseObj
+
+                if (responseObj.error != null) {
+                  ctx.autoRetry = true
+                  ctx.error = responseObj.error
+                }
+                // then set koa response from responseObj.response
+                setKoaResponse(ctx, responseObj.response)
+              });
+
             } else {
               setKoaResponse(ctx, response)
             }


### PR DESCRIPTION
This was due to the change to read an incoming stream instead of a full payload.
This change takes the reponse.body stream and builds up a string with all the supplied chuncks before setting the koa response.
We need to read in the entire payload here to process the mediator medatadata being supplied in the response