### PR TITLE
Bug fix transaction sequence metrics capture

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -22,16 +22,23 @@ async function recordTransactionMetric (fields, update) {
 export async function recordTransactionMetrics (transaction) {
   if (
       !transaction.response ||
-      !transaction.response.timestamp ||
-      !(transaction.response.timestamp instanceof Date)
+      !transaction.response.timestampEnd ||
+      !(transaction.response.timestampEnd instanceof Date)
   ) {
     // Don't record metrics if there is no response i.e. an error
     // or if the response does not have a timestamp
     // or if the timestamp isnt an instance of Date
+    /*
+     *   TODO: This may not be a critical requirement, but we
+     *      shouldn't be doing nothing under these conditions,
+     *      at the bery least, this case will cause a discrepancy
+     *      in the metrics. On the other hand, do we want to throw
+     *      an error here?
+     */
     return
   }
 
-  const responseTime = transaction.response.timestamp.getTime() - transaction.request.timestamp.getTime()
+  const responseTime = transaction.response.timestampEnd.getTime() - transaction.request.timestamp.getTime()
   const statusKey = TRANSACTION_STATUS_KEYS[transaction.status]
   const update = {
     $inc: {

--- a/src/middleware/router.js
+++ b/src/middleware/router.js
@@ -235,8 +235,7 @@ function sendRequestToRoutes (ctx, routes, next) {
                 }
                 // then set koa response from responseObj.response
                 setKoaResponse(ctx, responseObj.response)
-              });
-
+              })
             } else {
               setKoaResponse(ctx, response)
             }
@@ -251,6 +250,7 @@ function sendRequestToRoutes (ctx, routes, next) {
           .catch((reason) => {
             // on failure
             handleServerError(ctx, reason)
+            setTransactionFinalStatus(ctx)
             return next()
           })
       } else {

--- a/src/middleware/router.js
+++ b/src/middleware/router.js
@@ -343,11 +343,19 @@ const buildNonPrimarySendRequestPromise = (ctx, route, options, path) =>
       }
       if (response.headers != null && response.headers['content-type'] != null && response.headers['content-type'].indexOf('application/json+openhim') > -1) {
         // handle mediator reponse
-        const responseObj = JSON.parse(response.body)
-        routeObj.mediatorURN = responseObj['x-mediator-urn']
-        routeObj.orchestrations = responseObj.orchestrations
-        routeObj.properties = responseObj.properties
-        if (responseObj.metrics) { routeObj.metrics = responseObj.metrics }
+        let payload = ''
+        response.body.on('data', (data) => {
+          payload += data.toString()
+        })
+
+        response.body.on('end', () => {
+          const responseObj = JSON.parse(payload)
+          routeObj.mediatorURN = responseObj['x-mediator-urn']
+          routeObj.orchestrations = responseObj.orchestrations
+          routeObj.properties = responseObj.properties
+          if (responseObj.metrics) { routeObj.metrics = responseObj.metrics }
+          if (responseObj.error) { routeObj.error = responseObj.error }
+        })
         routeObj.response = responseObj.response
       } else {
         routeObj.response = response

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -300,7 +300,7 @@ async function rerunHttpRequestSend (options, transaction, callback) {
   options.responseBodyRequired = false
 
   try {
-    const response = await makeStreamingRequest(null, options, statusEvents)
+    await makeStreamingRequest(null, options, statusEvents)
     callback(null, response)
   } catch (err) {
     callback(err)

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -299,7 +299,12 @@ async function rerunHttpRequestSend (options, transaction, callback) {
   options.requestBodyRequired = ['POST', 'PUT', 'PATCH'].includes(transaction.request.method)
   options.responseBodyRequired = false
 
-  return await makeStreamingRequest(null, options, statusEvents)
+  try {
+    const response = await makeStreamingRequest(null, options, statusEvents)
+    callback(null, response)
+  } catch (err) {
+    callback(err)
+  }
 }
 
 /**


### PR DESCRIPTION
Addresses an issue where, under load, metrics were not being captured for all transactions (~2 out of 200). 
The issue is caused by the metrics update routine being called after the initial request information is persisted, but before the initial response information is available in the db (the metrics update required a responseTime for calculation, which was not available at that point). 

This change updates the calculation to require the response end-time instead of start-time, making the calculation more accurate, and also forces the setFinalStatus update to wait for completeResponse to complete before running. 