### PR TITLE
Release new version of the OpenHIM Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openhim-core",
   "description": "The OpenHIM core application that provides logging and routing of http requests",
-  "version": "5.2.6",
+  "version": "5.4.0",
   "main": "./lib/server.js",
   "bin": {
     "openhim-core": "./bin/openhim-core.js"


### PR DESCRIPTION
Version bumped to 5.4.0
This version should be replacing v5.3.0 as that version was incorrectly released. To avoid confusion, we are bumping this verion again with a minor version update

TRACE-137