### PR TITLE
OHM-1035 Remove logic that added transaction bodies

### DIFF
--- a/src/api/transactions.js
+++ b/src/api/transactions.js
@@ -336,31 +336,20 @@ export async function getTransactionById (ctx, transactionId) {
     // --------------Check if user has permission to view full content----------------- #
     // get projection object
     const projectionFiltersObject = getProjectionObject(filterRepresentation)
-
     const transaction = await TransactionModelAPI.findById(transactionId, projectionFiltersObject).exec()
-
-    // retrieve transaction request and response bodies
-    const resultArray = await addBodiesToTransactions([transaction])
-    const result = resultArray[0]
-
-    if (result && (filterRepresentation === 'fulltruncate')) {
-      truncateTransactionDetails(result)
-    }
-
-    // Test if the result if valid
-    if (!result) {
+    if (!transaction) {
       ctx.body = `Could not find transaction with ID: ${transactionId}`
       ctx.status = 404
       // Test if the user is authorised
     } else if (!authorisation.inGroup('admin', ctx.authenticated)) {
       const channels = await authorisation.getUserViewableChannels(ctx.authenticated)
-      if (getChannelIDsArray(channels).indexOf(result.channelID.toString()) >= 0) {
-        ctx.body = result
+      if (getChannelIDsArray(channels).indexOf(transaction.channelID.toString()) >= 0) {
+        ctx.body = transaction
       } else {
         return utils.logAndSetResponse(ctx, 403, `User ${ctx.authenticated.email} is not authenticated to retrieve transaction ${transactionId}`, 'info')
       }
     } else {
-      ctx.body = result
+      ctx.body = transaction
     }
   } catch (e) {
     utils.logAndSetResponse(ctx, 500, `Could not get transaction by ID via the API: ${e}`, 'error')

--- a/test/integration/transactionsAPITests.js
+++ b/test/integration/transactionsAPITests.js
@@ -979,7 +979,8 @@ describe('API Integration Tests', () => {
         res.body.request.headers['header-title'].should.equal('header1-value')
         res.body.request.headers['another-header'].should.equal('another-header-value')
         res.body.request.querystring.should.equal('param1=value1&param2=value2')
-        res.body.request.body.should.equal('<HTTP body request>')
+        should.exist(res.body.request.bodyId)
+        should.not.exist(res.body.request.body)
         res.body.request.method.should.equal('POST')
       })
 
@@ -1030,7 +1031,8 @@ describe('API Integration Tests', () => {
           .set('auth-token', authDetails.authToken)
           .expect(200)
 
-        res.body.request.body.should.equal(`<HTTP body${TRUNCATE_APPEND}`)
+        should.exist(res.body.request.bodyId)
+        should.not.exist(res.body.request.body)
       })
     })
 


### PR DESCRIPTION
Transaction bodies are stored separately and can be very large. We have
rewritten the OpenHIM to stream data instead of consolidating before
orchestrating.
We are implementing this same principle with interactions with the api
to improve response times.
If a request is made for transactions, a secondary request must be made
for the potentially large transaction bodies which will then be streamed
to the requester.

OHM-1035