### PR TITLE
Fix openhim transaction status

### DIFF
--- a/src/middleware/router.js
+++ b/src/middleware/router.js
@@ -404,6 +404,12 @@ const buildNonPrimarySendRequestPromise = (ctx, route, options, path) =>
       // on failure
       const routeObj = {}
       routeObj.name = route.name
+
+      if (!ctx.routes) {
+        ctx.routes = []
+      }
+      ctx.routes.push(routeObj)
+
       handleServerError(ctx, reason, routeObj)
       return routeObj
     })


### PR DESCRIPTION
Logic has been added to ensure that a response is added to the ctx.routes obect, which is checked when setting the transaction status. Errors in secondary routes were not being considered when the status was being set resulting in a status of 'successful' instead of 'completed with errors'

OHM-1080