### PR TITLE
feat: add docker support for arm64 platform

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,23 +16,27 @@ jobs:
         node-version: [14.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: jembi/openhim-core:latest

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -15,26 +15,30 @@ jobs:
         node-version: [14.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: jembi/openhim-core:${{ env.RELEASE_VERSION }}

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,6 @@
+{
+  "all": true,
+  "include": [
+    "src/**"
+  ]
+}

--- a/test/unit/messageStoreTest.js
+++ b/test/unit/messageStoreTest.js
@@ -145,6 +145,15 @@ describe('MessageStore', () => {
       })
     })
 
+    it('should fail to save invalid transaction', done => {
+      ctx.authorisedChannel._id = 'Invalid_ID'
+
+      messageStore.storeTransaction(ctx, (error) => {
+        error.message.should.match(/Transaction validation failed/)
+        return done()
+      })
+    })
+
     it('should be able to save the transaction if the headers contain Mongo reserved characters ($ or .)', done => {
       ctx.header['dot.header'] = '123'
       ctx.header.dollar$header = '124'
@@ -241,6 +250,15 @@ describe('MessageStore', () => {
             })
           )
         })
+      })
+    })
+
+    it('should fail to update a transactionthat does not exist', done => {
+      ctx.response = createResponse(201)
+      ctx.transactionId = 'Invalid_ID'
+      messageStore.storeResponse(ctx, err => {
+        err.message.should.match(/Cast to ObjectId failed/)
+        return done()
       })
     })
 


### PR DESCRIPTION
## Motivation

Failed to fetch docker image for MacOS (missing M1 arm64 platform build).

Github action config was updated according to docker documentation to publish multi-platform images : 
https://docs.docker.com/build/ci/github-actions/multi-platform/

Related PRs : https://github.com/jembi/openhim-console/pull/607