### PR TITLE
fix: update old password hash (deprecated token strategy)

### DIFF
--- a/src/model/users.js
+++ b/src/model/users.js
@@ -107,19 +107,21 @@ export const updateUser = async function (newUserData) {
     if (userToBeUpdated.password) {
       // Compute passport new hash for local strategy
       password = await hashPassword(userToBeUpdated.password)
+
       /* --- @deprecated : Update password hash for token strategy --- */
       const passport = await PassportModelAPI.findOne({
         protocol: 'token',
-        user: user.id
+        email: userToBeUpdated.email
       })
       if (passport) {
-        let shasum = crypto.createHash('sha512');
-        shasum.update(passport.passwordSalt + userToBeUpdated.password);
-        const passhash = shasum.digest('hex');
+        let shasum = crypto.createHash(passport.passwordAlgorithm)
+        shasum.update(passport.passwordSalt + userToBeUpdated.password)
+        const passhash = shasum.digest('hex')
         passport.passwordHash = passhash
-        await PassportModelAPI.findByIdAndUpdate(passport.id, passport);
+        await PassportModelAPI.findByIdAndUpdate(passport.id, passport)
       }
       /* --- ----------- --- */
+
       delete userToBeUpdated.password
     }
 

--- a/src/model/users.js
+++ b/src/model/users.js
@@ -104,8 +104,15 @@ export const updateUser = async function (newUserData) {
   try {
     let password
     if (userToBeUpdated.password) {
+      // Compute passport hash
       password = await hashPassword(userToBeUpdated.password)
-
+      /* --- @deprecated : Update password hash (auth with token) --- */
+      const { passwordSalt } = await UserModelAPI.findByIdAndUpdate(userToBeUpdated.id);
+      let shasum = crypto.createHash('sha512');
+      shasum.update(salt + userToBeUpdated.password);
+      const passhash = shasum.digest('hex');
+      userToBeUpdated.hashPassword = passhash;
+      /* --- ----------- --- */
       delete userToBeUpdated.password
     }
 


### PR DESCRIPTION
## Motivation

Updating the password does not update the old hash value in passport collection. 

How to reproduce  :
- Open OpenHIM (fresh install)
- First login with root@openhim.org / openhim-password
- Reset password (BUG : passwordHash stays the same)
- Run the openhim mapping mediator -> fails to authenticate.