### PR TITLE
fix: trust proxy ssl to forward session cookie

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -46,6 +46,8 @@ The following config option are provided by the OpenHIM. All of these options ha
     "sessionKey": "r8q,+&1LM3)CD*zAGpx1xm{NeQhc;#",
     // If OpenHIM is behind a proxy (should be `true` if the ssl is handled by the proxy)
     "trustProxy": false,
+    // Secure the cookie (either protocol is https or trusting a secured proxy)
+    secureCookie: true,
     // The session max age is the session cookie expiration time (in milliseconds)
     "maxAge": 7200000,
     // The number of characters that will be used to generate a random salt for the encryption of passwords

--- a/config/config.md
+++ b/config/config.md
@@ -44,6 +44,8 @@ The following config option are provided by the OpenHIM. All of these options ha
     // The session secret key used for the hashing of signed cookie (used to detect if the client modified the cookie)
     // Signed cookie is another cookie of the same name with the .sig suffix appended
     "sessionKey": "r8q,+&1LM3)CD*zAGpx1xm{NeQhc;#",
+    // If OpenHIM is behind a proxy (should be `true` if the ssl is handled by the proxy)
+    "trustProxy": false,
     // The session max age is the session cookie expiration time (in milliseconds)
     "maxAge": 7200000,
     // The number of characters that will be used to generate a random salt for the encryption of passwords

--- a/config/config.md
+++ b/config/config.md
@@ -44,7 +44,7 @@ The following config option are provided by the OpenHIM. All of these options ha
     // The session secret key used for the hashing of signed cookie (used to detect if the client modified the cookie)
     // Signed cookie is another cookie of the same name with the .sig suffix appended
     "sessionKey": "r8q,+&1LM3)CD*zAGpx1xm{NeQhc;#",
-    // If OpenHIM is behind a proxy (should be `true` if the ssl is handled by the proxy)
+    // If OpenHIM is behind a proxy (should be `true` if the proxy sends relevant Forwarded headers)
     "trustProxy": false,
     // Secure the cookie (either protocol is https or trusting a secured proxy)
     secureCookie: true,

--- a/config/default.json
+++ b/config/default.json
@@ -33,6 +33,7 @@
   "api": {
     "sessionKey": "r8q,+&1LM3)CD*zAGpx1xm{NeQhc;#",
     "trustProxy": false,
+    "secureCookie": true,
     "maxAge": 7200000,
     "salt": 10,
     "enabled": true,

--- a/config/default.json
+++ b/config/default.json
@@ -32,6 +32,7 @@
   },
   "api": {
     "sessionKey": "r8q,+&1LM3)CD*zAGpx1xm{NeQhc;#",
+    "trustProxy": false,
     "maxAge": 7200000,
     "salt": 10,
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openhim-core",
   "description": "The OpenHIM core application that provides logging and routing of http requests",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "main": "./lib/server.js",
   "bin": {
     "openhim-core": "./bin/openhim-core.js"

--- a/src/koaApi.js
+++ b/src/koaApi.js
@@ -40,12 +40,17 @@ export function setupApp(done) {
 
   // Configure Sessions Middleware
   app.keys = [config.api.sessionKey]
+  
+  if (config.api.trustProxy) {
+    app.proxy = true;
+  }
+  
   app.use(
     session(
       {
         maxAge: config.api.maxAge || 7200000,
         resave: false,
-        secure: true,
+        secure: config.api.protocol === 'https',
         httpOnly: true,
         sameSite: 'none',
         store: new MongooseStore()

--- a/src/koaApi.js
+++ b/src/koaApi.js
@@ -42,7 +42,7 @@ export function setupApp(done) {
   app.keys = [config.api.sessionKey]
   
   if (config.api.trustProxy) {
-    app.proxy = true;
+    app.proxy = true
   }
   
   app.use(

--- a/src/koaApi.js
+++ b/src/koaApi.js
@@ -50,7 +50,7 @@ export function setupApp(done) {
       {
         maxAge: config.api.maxAge || 7200000,
         resave: false,
-        secure: config.api.protocol === 'https',
+        secure: config.api.secureCookie,
         httpOnly: true,
         sameSite: 'none',
         store: new MongooseStore()


### PR DESCRIPTION
## Motivation

I was deploying OpenHIM for Indonesia on Google Cloud Run. OpenHIM is served behing a proxy that issues the SSL.
It was impossible to connect through OpenHIM console. When checking the logs I found the following error : "Error: Cannot send secure cookie over unencrypted connection"
Basically, you cannot set "secure=true" for the cookie and then serve it in HTTP. For that we needed that option to trust that the proxy.

Check : https://github.com/koajs/koa/issues/974

NOTE : This should be tested in platform.