### PR TITLE
adding empty header obj to pass condition

### DIFF
--- a/src/middleware/router.js
+++ b/src/middleware/router.js
@@ -670,7 +670,8 @@ function sendKafkaRequest(ctx, route) {
             resolve({
               status: 200,
               body: JSON.stringify(res),
-              timestamp: +new Date()
+              timestamp: +new Date(),
+              headers: {}
             })
           })
       })


### PR DESCRIPTION
The reason the header were not attached is due to the condition on line 59 of router.js, because the object returned from Kafka did not have a "headers" property this check always evaluated to false so the Transaction ID is never added.