### PR TITLE
Change Icon type to String and add Application type field to in AppSchema

### DIFF
--- a/src/model/apps.js
+++ b/src/model/apps.js
@@ -13,6 +13,10 @@ const AppSchema = new Schema({
   description: String,
   icon: {
     type: String  },
+  type: {
+    type: String,
+    enum: ['link', 'embedded'],
+    },
   category: String,
   access_roles: [String],
   url: {

--- a/src/model/apps.js
+++ b/src/model/apps.js
@@ -12,9 +12,7 @@ const AppSchema = new Schema({
   },
   description: String,
   icon: {
-    data: Buffer,
-    contentType: String
-  },
+    type: String  },
   category: String,
   access_roles: [String],
   url: {


### PR DESCRIPTION
Replaced the application Icon type from Buffer to String and added application type (which can holds either "link" or "embedded" as values) 