### PR TITLE
Add optional Openid connect provider issuer url to config and update passport.js to use it

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -84,6 +84,8 @@ The following config option are provided by the OpenHIM. All of these options ha
     "openid": {
       // Openid connect provider realm url link
       "url": "http://localhost:9088/realms/platform-realm",
+      // (Optional) Openid connect provider issuer url incase this is different from the api url e.g. if you are using a proxy
+      "issuerUrl": "http://localhost:9088/realms/platform-realm",
       // Callback URL used by openid connect provider (should be the same callback URL specified in realm)
       "callbackUrl": "http://localhost:9000",
       // CLient ID specified in the realm

--- a/src/passport.js
+++ b/src/passport.js
@@ -52,7 +52,7 @@ passport.loadStrategies = function () {
     openid: {
       strategy: passportOpenid.Strategy,
       options: {
-        issuer: openidConfig.url,
+        issuer: openidConfig.issuerUrl || openidConfig.url,
         authorizationURL: `${openidConfig.url}/protocol/openid-connect/auth`,
         tokenURL: `${openidConfig.url}/protocol/openid-connect/token`,
         userInfoURL: `${openidConfig.url}/protocol/openid-connect/userinfo`,


### PR DESCRIPTION
This pull request adds the ability to specify an optional Openid connect provider issuer url in the config file. If provided, passport.js will use this url instead of the api url. This change ensures that the correct issuer url is used when using a proxy.