### PR TITLE
Update enum values for OpenHIM Apps type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openhim-core",
   "description": "The OpenHIM core application that provides logging and routing of http requests",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "main": "./lib/server.js",
   "bin": {
     "openhim-core": "./bin/openhim-core.js"

--- a/src/model/apps.js
+++ b/src/model/apps.js
@@ -14,7 +14,7 @@ const AppSchema = new Schema({
   icon: String,
   type: {
     type: String,
-    enum: ['link', 'embedded']
+    enum: ['internal', 'external', 'esmodule']
   },
   category: String,
   access_roles: [String],

--- a/test/integration/appsAPITests.js
+++ b/test/integration/appsAPITests.js
@@ -20,7 +20,7 @@ describe('API Integration Tests', () => {
       name: 'Test app',
       description: 'An app for testing the app framework',
       icon: 'data:image/png;base64, <base64>',
-      type: 'link',
+      type: 'external',
       category: 'Operations',
       access_roles: ['test-app-user'],
       url: 'http://test-app.org/app',

--- a/test/unit/appsTest.js
+++ b/test/unit/appsTest.js
@@ -32,7 +32,7 @@ describe('Apps', () => {
         name: 'Test app1',
         description: 'An app for testing the app framework',
         icon: 'data:image/png;base64, <base64>',
-        type: 'link',
+        type: 'external',
         category: 'Operations',
         access_roles: ['test-app-user'],
         url: 'http://test-app.org/app1',


### PR DESCRIPTION
This pull request proposes modifying the Apps schema's type attribute to:

- New enum values: Replace `['link', 'embedded']` with `['internal', 'external', 'esmodule']`.

However, I'd like to open a discussion about alternative naming options :
- `built-in `: OpenHIM Console core module or internal pages
- `shortcut`: link to an external web page or app
- `in-browser-module`: link to one of Jembi's or third-party bundled ESModules   

