### PR TITLE
Return a generic response for password reset requests

### DIFF
--- a/src/api/users.js
+++ b/src/api/users.js
@@ -137,6 +137,18 @@ export const logout = async function (ctx) {
  * Reset password Functions
  */
 
+const PASSWORD_RESET_REQUEST_MESSAGE =
+  'Please check your email for password reset instructions.'
+
+function sendPasswordResetRequestResponse(ctx) {
+  ctx.body = PASSWORD_RESET_REQUEST_MESSAGE
+  ctx.status = 201
+}
+
+function isPasswordResetEligible(user) {
+  return user.provider !== 'openid' && user.locked !== true
+}
+
 const passwordResetPlainMessageTemplate = (firstname, setPasswordLink) => `\
 <---------- Existing User - Reset Password ---------->
 Hi ${firstname},
@@ -163,52 +175,43 @@ function generateRandomToken() {
  */
 export async function userPasswordResetRequest(ctx, email) {
   email = unescape(email)
-  if (email === 'root@openhim.org') {
-    ctx.body = "Cannot request password reset for 'root@openhim.org'"
-    ctx.status = 403
-    return
-  }
-
-  // Generate the new user token here
-  // set expiry date = true
-  const token = generateRandomToken()
-  const {duration, durationType} = config.userPasswordResetExpiry
-  const expiry = moment().add(duration, durationType).utc().format()
-
-  const updateUserTokenExpiry = {
-    token,
-    tokenType: 'existingUser',
-    expiry
-  }
 
   try {
+    if (email === 'root@openhim.org') {
+      logger.info(`Password reset request declined for root user: ${email}`)
+      return sendPasswordResetRequestResponse(ctx)
+    }
+
     const user = await UserModelAPI.findOne({
       email: utils.caseInsensitiveRegex(email)
     })
     if (!user) {
-      ctx.body = `Tried to request password reset for invalid email address: ${email}`
-      ctx.status = 404
-      logger.info(
-        `Tried to request password reset for invalid email address: ${email}`
-      )
-      return
+      logger.info(`Password reset request for unknown email address: ${email}`)
+      return sendPasswordResetRequestResponse(ctx)
     }
 
-    if (user.provider === 'openid') {
-      ctx.body = `User supplied by OpenID Connect provider. Cannot request password reset.`
-      ctx.status = 403
-      logger.info(
-        `Tried to request password reset for a user supplied by OpenID Connect provider: ${email}`
-      )
-      return
+    if (!isPasswordResetEligible(user)) {
+      const reason =
+        user.provider === 'openid'
+          ? 'OpenID Connect user'
+          : 'inactive user account'
+      logger.info(`Password reset request declined for ${reason}: ${email}`)
+      return sendPasswordResetRequestResponse(ctx)
     }
 
-    await UserModelAPI.findByIdAndUpdate(user.id, updateUserTokenExpiry)
+    const token = generateRandomToken()
+    const {duration, durationType} = config.userPasswordResetExpiry
+    const expiry = moment().add(duration, durationType).utc().format()
+
+    await UserModelAPI.findByIdAndUpdate(user.id, {
+      token,
+      tokenType: 'existingUser',
+      expiry
+    })
 
     const {consoleURL} = config.alerts
     const setPasswordLink = `${consoleURL}/#!/set-password/${token}`
 
-    // Send email to user to reset password
     const plainMessage = passwordResetPlainMessageTemplate(
       user.firstname,
       setPasswordLink
@@ -227,26 +230,19 @@ export async function userPasswordResetRequest(ctx, email) {
       htmlMessage
     )
     if (sendEmailError) {
-      utils.logAndSetResponse(
-        ctx,
-        500,
-        `Could not send email to user via the API ${sendEmailError}`,
-        'error'
+      logger.error(
+        `Could not send password reset email to ${email}: ${sendEmailError}`
       )
-      return
+      return sendPasswordResetRequestResponse(ctx)
     }
 
-    logger.info('The email has been sent to the user')
-    ctx.body = 'Successfully set user token/expiry for password reset.'
-    ctx.status = 201
-    return logger.info(`User updated token/expiry for password reset ${email}`)
+    logger.info(`Password reset email sent for ${email}`)
+    return sendPasswordResetRequestResponse(ctx)
   } catch (error) {
-    utils.logAndSetResponse(
-      ctx,
-      500,
-      `Could not update user with email ${email} via the API ${error}`,
-      'error'
+    logger.error(
+      `Could not process password reset request for ${email}: ${error}`
     )
+    return sendPasswordResetRequestResponse(ctx)
   }
 }
 

--- a/test/integration/usersAPITests.js
+++ b/test/integration/usersAPITests.js
@@ -164,25 +164,66 @@ describe('API Integration Tests', () => {
     })
 
     describe('*userPasswordResetRequest(email)', () => {
-      it('should return 403 when requesting root@openhim.org password reset', async () => {
-        await request(BASE_URL)
+      const passwordResetResponse =
+        'Please check your email for password reset instructions.'
+
+      it('should return a generic response when requesting root@openhim.org password reset', async () => {
+        const res = await request(BASE_URL)
           .get('/password-reset-request/root@openhim.org')
-          .expect(403)
+          .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
       })
 
-      it('should return 403 when requesting a keycloak user password reset', async () => {
-        await request(BASE_URL)
+      it('should return a generic response when requesting a keycloak user password reset', async () => {
+        const userBefore = await UserModelAPI.findOne({
+          email: 'test@keycloak.net'
+        })
+
+        const res = await request(BASE_URL)
           .get('/password-reset-request/test@keycloak.net')
-          .expect(403)
+          .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
+
+        const userAfter = await UserModelAPI.findOne({
+          email: 'test@keycloak.net'
+        })
+        userAfter.token.should.eql(userBefore.token)
+        userAfter.tokenType.should.eql(userBefore.tokenType)
+      })
+
+      it('should return a generic response for an inactive user account', async () => {
+        await UserModelAPI.findOneAndUpdate(
+          {email: 'bfm@crazy.net'},
+          {locked: true}
+        )
+        const userBefore = await UserModelAPI.findOne({email: 'bfm@crazy.net'})
+
+        const res = await request(BASE_URL)
+          .get('/password-reset-request/bfm@crazy.net')
+          .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
+
+        const userAfter = await UserModelAPI.findOne({email: 'bfm@crazy.net'})
+        userAfter.token.should.eql(userBefore.token)
+        userAfter.tokenType.should.eql(userBefore.tokenType)
+        await UserModelAPI.findOneAndUpdate(
+          {email: 'bfm@crazy.net'},
+          {locked: false}
+        )
       })
 
       it('should update the user with a token and send reset email', async () => {
         const stubContact = await sinon.stub(contact, 'sendEmail')
         await stubContact.yields(null)
 
-        await request(BASE_URL)
+        const res = await request(BASE_URL)
           .get('/password-reset-request/r..@jembi.org')
           .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
 
         const user = await UserModelAPI.findOne({email: 'r..@jembi.org'})
         user.should.have.property('firstname', 'Ryan')
@@ -197,9 +238,11 @@ describe('API Integration Tests', () => {
         const stubContact = await sinon.stub(contact, 'sendEmail')
         await stubContact.yields(null)
 
-        await request(BASE_URL)
+        const res = await request(BASE_URL)
           .get('/password-reset-request/R..@jembi.org')
           .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
 
         const user = await UserModelAPI.findOne({email: user1.email})
         user.should.have.property('firstname', 'Ryan')
@@ -207,22 +250,30 @@ describe('API Integration Tests', () => {
         await stubContact.restore()
       })
 
-      it('should update the user with a token get a 500 error when nodemailer fails', async () => {
+      it('should update the user with a token and return a generic response when nodemailer fails', async () => {
         const stubContact = await sinon.stub(contact, 'sendEmail')
 
         await stubContact.yields('An error occurred trying to send the email.')
 
-        await request(BASE_URL)
+        const res = await request(BASE_URL)
           .get('/password-reset-request/r..@jembi.org')
-          .expect(500)
+          .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
+
+        const user = await UserModelAPI.findOne({email: 'r..@jembi.org'})
+        user.should.have.property('tokenType', 'existingUser')
+        should.exist(user.token)
 
         await stubContact.restore()
       })
 
-      it('should return a not found error', async () => {
-        await request(BASE_URL)
+      it('should return a generic response for an unknown email address', async () => {
+        const res = await request(BASE_URL)
           .get('/password-reset-request/test@jembi.org')
-          .expect(404)
+          .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
       })
     })
 
@@ -831,19 +882,48 @@ describe('API Integration Tests', () => {
     })
 
     describe('*userPasswordResetRequest(email)', () => {
-      it('should return 403 when requesting root@openhim.org password reset', async () => {
-        await request(BASE_URL)
+      const passwordResetResponse =
+        'Please check your email for password reset instructions.'
+
+      it('should return a generic response when requesting root@openhim.org password reset', async () => {
+        const res = await request(BASE_URL)
           .get('/password-reset-request/root@openhim.org')
-          .expect(403)
+          .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
+      })
+
+      it('should return a generic response for an inactive user account', async () => {
+        await UserModelAPI.findOneAndUpdate(
+          {email: 'bfm@crazy.net'},
+          {locked: true}
+        )
+        const userBefore = await UserModelAPI.findOne({email: 'bfm@crazy.net'})
+
+        const res = await request(BASE_URL)
+          .get('/password-reset-request/bfm@crazy.net')
+          .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
+
+        const userAfter = await UserModelAPI.findOne({email: 'bfm@crazy.net'})
+        userAfter.token.should.eql(userBefore.token)
+        userAfter.tokenType.should.eql(userBefore.tokenType)
+        await UserModelAPI.findOneAndUpdate(
+          {email: 'bfm@crazy.net'},
+          {locked: false}
+        )
       })
 
       it('should update the user with a token and send reset email', async () => {
         const stubContact = await sinon.stub(contact, 'sendEmail')
         await stubContact.yields(null)
 
-        await request(BASE_URL)
+        const res = await request(BASE_URL)
           .get('/password-reset-request/r..@jembi.org')
           .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
 
         const user = await UserModelAPI.findOne({email: 'r..@jembi.org'})
         user.should.have.property('firstname', 'Ryan')
@@ -858,9 +938,11 @@ describe('API Integration Tests', () => {
         const stubContact = await sinon.stub(contact, 'sendEmail')
         await stubContact.yields(null)
 
-        await request(BASE_URL)
+        const res = await request(BASE_URL)
           .get('/password-reset-request/R..@jembi.org')
           .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
 
         const user = await UserModelAPI.findOne({email: user1.email})
         user.should.have.property('firstname', 'Ryan')
@@ -868,22 +950,30 @@ describe('API Integration Tests', () => {
         await stubContact.restore()
       })
 
-      it('should update the user with a token get a 500 error when nodemailer fails', async () => {
+      it('should update the user with a token and return a generic response when nodemailer fails', async () => {
         const stubContact = await sinon.stub(contact, 'sendEmail')
 
         await stubContact.yields('An error occurred trying to send the email.')
 
-        await request(BASE_URL)
+        const res = await request(BASE_URL)
           .get('/password-reset-request/r..@jembi.org')
-          .expect(500)
+          .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
+
+        const user = await UserModelAPI.findOne({email: 'r..@jembi.org'})
+        user.should.have.property('tokenType', 'existingUser')
+        should.exist(user.token)
 
         await stubContact.restore()
       })
 
-      it('should return a not found error', async () => {
-        await request(BASE_URL)
+      it('should return a generic response for an unknown email address', async () => {
+        const res = await request(BASE_URL)
           .get('/password-reset-request/test@jembi.org')
-          .expect(404)
+          .expect(201)
+
+        res.text.should.eql(passwordResetResponse)
       })
     })
 

--- a/test/integration/usersAPITests.js
+++ b/test/integration/usersAPITests.js
@@ -207,8 +207,9 @@ describe('API Integration Tests', () => {
         res.text.should.eql(passwordResetResponse)
 
         const userAfter = await UserModelAPI.findOne({email: 'bfm@crazy.net'})
-        userAfter.token.should.eql(userBefore.token)
-        userAfter.tokenType.should.eql(userBefore.tokenType)
+        should.equal(userAfter.token, userBefore.token)
+        should.equal(userAfter.tokenType, userBefore.tokenType)
+        userAfter.locked.should.eql(true)
         await UserModelAPI.findOneAndUpdate(
           {email: 'bfm@crazy.net'},
           {locked: false}
@@ -907,8 +908,9 @@ describe('API Integration Tests', () => {
         res.text.should.eql(passwordResetResponse)
 
         const userAfter = await UserModelAPI.findOne({email: 'bfm@crazy.net'})
-        userAfter.token.should.eql(userBefore.token)
-        userAfter.tokenType.should.eql(userBefore.tokenType)
+        should.equal(userAfter.token, userBefore.token)
+        should.equal(userAfter.tokenType, userBefore.tokenType)
+        userAfter.locked.should.eql(true)
         await UserModelAPI.findOneAndUpdate(
           {email: 'bfm@crazy.net'},
           {locked: false}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Password reset requests now return a consistent response, regardless of whether an account exists, is eligible, or email delivery succeeds.
  * Reduced exposure of account status and authentication details.

* **Bug Fixes**
  * Password reset requests now handle email addresses case-insensitively.
  * Improved handling for locked, inactive, and externally managed accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->