### PR TITLE
Add current password field to self-service password change forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhim-core",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhim-core",
-      "version": "8.5.0",
+      "version": "8.5.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.7",

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -17,6 +17,7 @@ import {
   updateTokenUser
 } from '../model/users'
 import {PassportModelAPI, createPassport} from '../model/passport'
+import MongooseStore from '../middleware/sessionStore'
 import {config} from '../config'
 
 config.newUserExpiry = config.get('newUserExpiry')
@@ -517,6 +518,21 @@ export async function addUser(ctx) {
   }
 }
 
+const passwordChangedPlainMessageTemplate = firstname => `\
+<---------- Password Changed ---------->
+Hi ${firstname},
+
+The password for your OpenHIM Console account on ${config.alerts.himInstance} has just been changed.
+If you did not make this change, please contact your OpenHIM administrator immediately.
+<---------- Password Changed ---------->\
+`
+
+const passwordChangedHtmlMessageTemplate = firstname => `\
+<h1>OpenHIM Password Changed</h1>
+<p>Hi ${firstname},<br/><br/>The password for your OpenHIM Console account on ${config.alerts.himInstance} has just been changed.</p>
+<p>If you did not make this change, please contact your OpenHIM administrator immediately.</p>\
+`
+
 /*
  * Retrieves the details of a specific user
  */
@@ -586,13 +602,38 @@ export async function updateUser(ctx, email) {
   }
 
   let {_doc: userData} = new UserModelAPI(ctx.request.body)
-  const {password} = ctx.request.body
+  const {password, currentPassword} = ctx.request.body
 
   // @deprecated
   const {passwordAlgorithm, passwordHash, passwordSalt} = ctx.request.body
 
+  const passwordChangeRequested = Boolean(
+    password || (passwordAlgorithm && passwordHash && passwordSalt)
+  )
+  const isSelfService = ctx.authenticated.email === email
+  const genericPasswordChangeError =
+    'Current password is required and must be correct to change your password.'
+
+  // A user changing their own password must re-confirm it server-side first.
+  // Client-side confirmation alone is not sufficient to prove they know the current password.
+  if (
+    passwordChangeRequested &&
+    isSelfService &&
+    userDetails.provider !== 'openid'
+  ) {
+    const currentPasswordValid = await utils.verifyCurrentPassword(
+      userDetails,
+      currentPassword
+    )
+
+    if (!currentPasswordValid) {
+      utils.logAndSetResponse(ctx, 400, genericPasswordChangeError, 'info')
+      return
+    }
+  }
+
   // reset token/locked/expiry when user is updated and password supplied
-  if (password || (passwordAlgorithm && passwordHash && passwordSalt)) {
+  if (passwordChangeRequested) {
     userData.token = null
     userData.tokenType = null
     userData.locked = false
@@ -651,6 +692,35 @@ export async function updateUser(ctx, email) {
       logger.info(
         `User ${ctx.authenticated.email} updated user ${userData.email}`
       )
+
+      if (passwordChangeRequested) {
+        logger.info(
+          `Password changed for user ${userDetails.email} by ${ctx.authenticated.email}`
+        )
+
+        try {
+          await new MongooseStore().destroyAllForUser(userDetails.email)
+        } catch (sessionError) {
+          logger.error(
+            `Could not invalidate existing sessions for ${userDetails.email} after password change ${sessionError}`
+          )
+        }
+
+        contact.contactUser(
+          'email',
+          userDetails.email,
+          'OpenHIM Console Password Changed',
+          passwordChangedPlainMessageTemplate(userDetails.firstname),
+          passwordChangedHtmlMessageTemplate(userDetails.firstname),
+          err => {
+            if (err) {
+              logger.error(
+                `Could not send password change notification email to ${userDetails.email} ${err}`
+              )
+            }
+          }
+        )
+      }
     } else {
       ctx.throw(500, error)
     }

--- a/src/middleware/sessionStore.js
+++ b/src/middleware/sessionStore.js
@@ -32,6 +32,14 @@ class MongooseStore {
     return session.deleteOne({_id: id})
   }
 
+  /**
+   * Invalidate every active session belonging to a user, e.g. after a password change.
+   */
+  async destroyAllForUser(email) {
+    const {session} = this
+    return session.deleteMany({'data.passport.user': email})
+  }
+
   async get(id) {
     const {session} = this
     const {data} = (await session.findById(id)) || {}

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,7 @@ import _ from 'lodash'
 import {ChannelModel} from './model/channels'
 import {RoleModelAPI} from './model/role'
 import {KeystoreModel} from './model/keystore'
+import {PassportModelAPI} from './model/passport'
 import {config} from './config'
 
 config.caching = config.get('caching')
@@ -208,6 +209,33 @@ export const validatePassword = function (passport, password, next) {
   } else {
     bcrypt.compare(password, passport.password, next)
   }
+}
+
+/**
+ * Verify that the supplied current password matches the password on record for a user.
+ *
+ * Used to re-authenticate a user server-side before allowing a password change,
+ * since client-side confirmation alone can be bypassed.
+ */
+export const verifyCurrentPassword = async function (user, currentPassword) {
+  if (!user || !currentPassword) {
+    return false
+  }
+
+  const passport = await PassportModelAPI.findOne({
+    protocol: user.provider === 'token' ? 'token' : 'local',
+    email: user.email
+  })
+
+  if (!passport) {
+    return false
+  }
+
+  return new Promise(resolve => {
+    validatePassword(passport, currentPassword, (err, res) => {
+      resolve(Boolean(!err && res))
+    })
+  })
 }
 
 /**

--- a/test/integration/usersAPITests.js
+++ b/test/integration/usersAPITests.js
@@ -663,6 +663,98 @@ describe('API Integration Tests', () => {
         user.groups.should.be.length(2)
         user.groups.should.not.containEql('admin')
       })
+
+      it('should reject a self password change with no currentPassword supplied', async () => {
+        const cookie = await testUtils.authenticate(
+          request,
+          BASE_URL,
+          testUtils.nonRootUser1
+        )
+
+        const res = await request(BASE_URL)
+          .put(`/users/${testUtils.nonRootUser1.email}`)
+          .set('Cookie', cookie)
+          .send({password: 'a-new-password'})
+          .expect(400)
+
+        res.text.should.match(/current password/i)
+
+        // password should not have been changed - old password still works
+        await testUtils.authenticate(request, BASE_URL, testUtils.nonRootUser1)
+      })
+
+      it('should reject a self password change with an incorrect currentPassword', async () => {
+        const cookie = await testUtils.authenticate(
+          request,
+          BASE_URL,
+          testUtils.nonRootUser1
+        )
+
+        await request(BASE_URL)
+          .put(`/users/${testUtils.nonRootUser1.email}`)
+          .set('Cookie', cookie)
+          .send({password: 'a-new-password', currentPassword: 'wrong-password'})
+          .expect(400)
+
+        // password should not have been changed - old password still works
+        await testUtils.authenticate(request, BASE_URL, testUtils.nonRootUser1)
+      })
+
+      it('should allow a self password change with the correct currentPassword, invalidate other sessions and notify the user', async () => {
+        const stubContact = sinon.stub(contact, 'sendEmail')
+        stubContact.yields(null)
+
+        // an existing session from another device/browser
+        const otherSessionCookie = await testUtils.authenticate(
+          request,
+          BASE_URL,
+          testUtils.nonRootUser1
+        )
+        await request(BASE_URL)
+          .get('/me')
+          .set('Cookie', otherSessionCookie)
+          .expect(200)
+
+        const cookie = await testUtils.authenticate(
+          request,
+          BASE_URL,
+          testUtils.nonRootUser1
+        )
+
+        await request(BASE_URL)
+          .put(`/users/${testUtils.nonRootUser1.email}`)
+          .set('Cookie', cookie)
+          .send({
+            password: 'a-new-password',
+            currentPassword: testUtils.nonRootUser1.password
+          })
+          .expect(200)
+
+        // the other, previously valid session should now be invalidated
+        await request(BASE_URL)
+          .get('/me')
+          .set('Cookie', otherSessionCookie)
+          .expect(404)
+
+        // a notification email should have been sent to the user
+        stubContact.called.should.be.true()
+
+        stubContact.restore()
+
+        // reset the password back so other tests relying on this fixture keep working
+        const newCookie = await testUtils.authenticate(request, BASE_URL, {
+          email: testUtils.nonRootUser1.email,
+          password: 'a-new-password'
+        })
+        await request(BASE_URL)
+          .put(`/users/${testUtils.nonRootUser1.email}`)
+          .set('Cookie', newCookie)
+          .send({
+            password: testUtils.nonRootUser1.password,
+            currentPassword: 'a-new-password'
+          })
+          .expect(200)
+      })
     })
 
     describe('*removeUser(email)', () => {


### PR DESCRIPTION
**Require current password to change your own password via PUT /users/:email**

Previously a valid session alone was enough to set a new password on
your own account, with no server-side check that the caller actually
knew the current one. Add server-side verification of a currentPassword
field for self-service password changes, invalidate all other active
sessions for the account, and notify the user by email once the
password is changed.


<img width="1742" height="81" alt="Screenshot from 2026-07-15 11-15-01" src="https://github.com/user-attachments/assets/3237fc3e-e87a-4d0d-a38f-ab01fd38a4f1" />


<img width="1833" height="92" alt="Screenshot from 2026-07-15 11-16-02" src="https://github.com/user-attachments/assets/13914375-a804-4aa5-a7ba-9cc0fb70adcb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Password changes now require verification of the current password.
  * Existing sessions are invalidated after a successful password change.
* **Notifications**
  * Added email notifications when a password is changed.
* **Bug Fixes**
  * Improved handling of password changes using legacy password fields.
* **Tests**
  * Added coverage for missing or incorrect current passwords, session invalidation, and notification delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->